### PR TITLE
Exclude gtest if LAF_WITH_TEST is disabled

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -37,5 +37,6 @@ target_include_directories(modpbase64 PUBLIC
 
 # ----------------------------------------------------------------------
 # googletest library
-
-add_subdirectory(googletest)
+if(LAF_WITH_TESTS)
+  add_subdirectory(googletest)
+endif()


### PR DESCRIPTION
Save some time during compilation and exclude unnecessary test framework when LAF_WITH_TEST=OFF