### PR TITLE
Fix Caps Lock has no effect on macOS

### DIFF
--- a/os/osx/keys.mm
+++ b/os/osx/keys.mm
@@ -409,13 +409,21 @@ CFStringRef get_unicode_from_key_code(const UInt16 keyCode,
   UniChar output[4];
   UniCharCount length;
 
+  // As UCKeyTranslate doesn't care about the Caps Lock flag,
+  // translate it into Shift
+  NSEventModifierFlags modifierFlagsHacked = modifierFlags;
+  if (modifierFlagsHacked & NSEventModifierFlagCapsLock) {
+    modifierFlagsHacked ^=
+     (NSEventModifierFlagCapsLock ^ NSEventModifierFlagShift);
+  }
+
   // Reference here:
   // https://developer.apple.com/reference/coreservices/1390584-uckeytranslate?language=objc
   UCKeyTranslate(
     keyLayout,
     keyCode,
     kUCKeyActionDown,
-    ((modifierFlags >> 16) & 0xFF),
+    ((modifierFlagsHacked >> 16) & 0xFF),
     LMGetKbdType(),
     (deadKeyState ? 0: kUCKeyTranslateNoDeadKeysMask),
     &deadKeyStateWrap,


### PR DESCRIPTION
Hi! Hope this can be of a little help (^ ^;)

It is a not-so-elegant workaround — I cannot find much information on how `UCKeyTranslate()` works, and this is the only way I can get the outcome correct so far. For now it seems that `UCKeyTranslate()` ignores the Caps Lock flag without Shift, and reads it with Shift, hence always disabling its function. I don't know the reason behind it, and I might, might be terribly wrong… I'd appreciate if anyone can provide a deeper insight into it!

Btw, this can fix aseprite/aseprite#1876.