### PR TITLE
Fix incorrect behaviour of macOS native dialogs

### DIFF
--- a/os/osx/native_dialogs.mm
+++ b/os/osx/native_dialogs.mm
@@ -68,6 +68,8 @@
   }
 
   display->setNativeMouseCursor(oldCursor);
+  NSWindow *window = (__bridge NSWindow *)display->nativeHandle();
+  [window makeKeyAndOrderFront:nil];
 }
 
 - (int)result

--- a/os/osx/native_dialogs.mm
+++ b/os/osx/native_dialogs.mm
@@ -50,6 +50,7 @@
 // This is executed in the main thread.
 - (void)runModal
 {
+  [[[NSApplication sharedApplication] mainMenu] setAutoenablesItems:NO];
   os::NativeCursor oldCursor = display->nativeMouseCursor();
   display->setNativeMouseCursor(os::kArrowCursor);
 
@@ -70,6 +71,7 @@
   display->setNativeMouseCursor(oldCursor);
   NSWindow *window = (__bridge NSWindow *)display->nativeHandle();
   [window makeKeyAndOrderFront:nil];
+  [[[NSApplication sharedApplication] mainMenu] setAutoenablesItems:YES];
 }
 
 - (int)result


### PR DESCRIPTION
Please refer to the commits for details. I have tested this on macOS 10.13.5, and everything about native dialogs and menus look fine now. (Refer to aseprite/aseprite#2037.)

On a sided note, I cannot reproduce aseprite/aseprite#1917, but it seems a related issue and I suppose it should be looked into.

Thanks for the effort and time! ^ ^