### PR TITLE
Extend rectangle packing algorithm with padding support

### DIFF
--- a/gfx/packing_rects.h
+++ b/gfx/packing_rects.h
@@ -17,6 +17,11 @@ namespace gfx {
   // TODO add support for rotations
   class PackingRects {
   public:
+    PackingRects(int borderPadding = 0, int shapePadding = 0) :
+      m_borderPadding(borderPadding),
+      m_shapePadding(shapePadding) {
+    }
+
     typedef std::vector<Rect> Rects;
     typedef Rects::const_iterator const_iterator;
 
@@ -44,6 +49,9 @@ namespace gfx {
     const Rect& bounds() const { return m_bounds; }
 
   private:
+    int m_borderPadding;
+    int m_shapePadding;
+
     Rect m_bounds;
     Rects m_rects;
   };

--- a/gfx/packing_rects_tests.cpp
+++ b/gfx/packing_rects_tests.cpp
@@ -95,6 +95,22 @@ TEST(PackingRects, KeepSameRectsOrder)
   EXPECT_EQ(Rect(0, 0, 30, 30), pr[2]);
 }
 
+TEST(PackingRects, BorderAndShapePadding)
+{
+  PackingRects pr(10, 3);
+  pr.add(Size(200, 100));
+  pr.add(Size(200, 100));
+  pr.add(Size(200, 100));
+
+  EXPECT_FALSE(pr.pack(Size(220, 325)));
+  EXPECT_FALSE(pr.pack(Size(219, 326)));
+  EXPECT_TRUE(pr.pack(Size(220, 326)));
+
+  EXPECT_EQ(Rect(10, 10, 200, 100), pr[0]);
+  EXPECT_EQ(Rect(10, 113, 200, 100), pr[1]);
+  EXPECT_EQ(Rect(10, 216, 200, 100), pr[2]);
+}
+
 #endif
 
 int main(int argc, char** argv)


### PR DESCRIPTION
I included a simple test, which has already helped me catch a bug ^ ^

Combined with aseprite/aseprite#2045, this tries to address aseprite/aseprite#1240.

![player](https://user-images.githubusercontent.com/45892908/55132653-13a70780-515e-11e9-883a-0c09e12f019c.png)

Hope it helps!