### PR TITLE
Keep supplied extension in macOS save dialogues

### DIFF
--- a/os/osx/native_dialogs.mm
+++ b/os/osx/native_dialogs.mm
@@ -118,13 +118,6 @@ public:
       [panel setTitle:[NSString stringWithUTF8String:m_title.c_str()]];
       [panel setCanCreateDirectories:YES];
 
-      std::string defPath = base::get_file_path(m_filename);
-      std::string defName = base::get_file_name(m_filename);
-      if (!defPath.empty())
-        [panel setDirectoryURL:[NSURL fileURLWithPath:[NSString stringWithUTF8String:defPath.c_str()]]];
-      if (!defName.empty())
-        [panel setNameFieldStringValue:[NSString stringWithUTF8String:defName.c_str()]];
-
       if (m_type != Type::OpenFolder && !m_filters.empty()) {
         NSMutableArray* types = [[NSMutableArray alloc] init];
         // The first extension in the array is used as the default one.
@@ -136,6 +129,13 @@ public:
         if (m_type == Type::SaveFile)
           [panel setAllowsOtherFileTypes:NO];
       }
+
+      std::string defPath = base::get_file_path(m_filename);
+      std::string defName = base::get_file_name(m_filename);
+      if (!defPath.empty())
+        [panel setDirectoryURL:[NSURL fileURLWithPath:[NSString stringWithUTF8String:defPath.c_str()]]];
+      if (!defName.empty())
+        [panel setNameFieldStringValue:[NSString stringWithUTF8String:defName.c_str()]];
 
       OpenSaveHelper* helper = [OpenSaveHelper new];
       [helper setPanel:panel];


### PR DESCRIPTION
The dialogue should keep the extension if it's among the allowed ones, or append the first one in the allowed list to the file name otherwise. Closes aseprite/aseprite#1835.

For some reason `setAllowedFileTypes:` overwrites the extension provided in `setNameFieldStringValue:`, so it needs to be done before the latter. Apparently [authors of electron have run into the same issue](https://github.com/electron/electron/blob/34c4c8d5088fa183f56baea28809de6f2a427e02/shell/browser/ui/file_dialog_mac.mm#L179)... Does this count as an upstream bug in AppKit? (=~=)