### PR TITLE
Fix macOS dialogues not responding to Cmd-AZXCV

### DIFF
--- a/os/osx/app.mm
+++ b/os/osx/app.mm
@@ -21,7 +21,7 @@ namespace os {
 class OSXApp::Impl {
 public:
   bool init() {
-    m_app = [NSApplication sharedApplication];
+    m_app = [OSXNSApplication sharedApplication];
     m_appDelegate = [OSXAppDelegate new];
 
     [m_app setActivationPolicy:NSApplicationActivationPolicyRegular];

--- a/os/osx/app_delegate.h
+++ b/os/osx/app_delegate.h
@@ -10,6 +10,12 @@
 
 #include <Cocoa/Cocoa.h>
 
+@interface OSXNSApplication : NSApplication
+
+- (void)sendEvent:(NSEvent *)event;
+
+@end
+
 @interface OSXAppDelegate : NSObject<NSApplicationDelegate>
 - (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication*)sender;
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication*)app;

--- a/os/osx/app_delegate.mm
+++ b/os/osx/app_delegate.mm
@@ -20,6 +20,45 @@
 #include "os/osx/view.h"
 #include "os/system.h"
 
+@implementation OSXNSApplication
+
+- (void)sendEvent:(NSEvent *)event
+{
+  if ([event type] == NSKeyDown) {
+    if (([event modifierFlags] & NSDeviceIndependentModifierFlagsMask) == NSCommandKeyMask) {
+      if ([[event charactersIgnoringModifiers] isEqualToString:@"x"]) {
+        if ([self sendAction:@selector(cut:) to:nil from:self])
+          return;
+      }
+      else if ([[event charactersIgnoringModifiers] isEqualToString:@"c"]) {
+        if ([self sendAction:@selector(copy:) to:nil from:self])
+          return;
+      }
+      else if ([[event charactersIgnoringModifiers] isEqualToString:@"v"]) {
+        if ([self sendAction:@selector(paste:) to:nil from:self])
+          return;
+      }
+      else if ([[event charactersIgnoringModifiers] isEqualToString:@"z"]) {
+        if ([self sendAction:@selector(undo:) to:nil from:self])
+          return;
+      }
+      else if ([[event charactersIgnoringModifiers] isEqualToString:@"a"]) {
+        if ([self sendAction:@selector(selectAll:) to:nil from:self])
+          return;
+      }
+    }
+    else if (([event modifierFlags] & NSDeviceIndependentModifierFlagsMask) == (NSCommandKeyMask | NSShiftKeyMask)) {
+      if ([[event charactersIgnoringModifiers] isEqualToString:@"Z"]) {
+        if ([self sendAction:@selector(redo:) to:nil from:self])
+          return;
+      }
+    }
+  }
+  [super sendEvent:event];
+}
+
+@end
+
 @protocol OSXValidateMenuItemProtocol
 - (void)validateMenuItem;
 @end


### PR DESCRIPTION
Closes aseprite/aseprite#1973.

I was sure this could not be achieved with an application delegate; an invisible menu would solve the problem, but might be quite cumbersome. Thus I ended up copying much code in [this StackOverflow post](https://stackoverflow.com/a/3176930) and it worked nicely.

I'm not sure whether this is the right way to name ("OSX" + "NS" looks unnecessary, but there is already an "OSXApp") and place the inherited class, so please specify if anything is to be changed. Thanks!