### PR TITLE
[osx] Use Retina display scale

### DIFF
--- a/os/osx/view.mm
+++ b/os/osx/view.mm
@@ -50,8 +50,9 @@ gfx::Point get_local_mouse_pos(NSView* view, NSEvent* event)
     scale = [(OSXWindow*)[view window] scale];
 
   // "os" layer coordinates expect (X,Y) origin at the top-left corner.
-  return gfx::Point(point.x / scale,
-                    (view.bounds.size.height - point.y) / scale);
+  float displayScale = view.window.backingScaleFactor;
+  return gfx::Point(point.x / scale * displayScale,
+                    (view.bounds.size.height - point.y) / scale * displayScale);
 }
 
 Event::MouseButton get_mouse_buttons(NSEvent* event)
@@ -189,11 +190,13 @@ using namespace os;
 - (void)drawRect:(NSRect)dirtyRect
 {
   [super drawRect:dirtyRect];
-  if (m_impl)
-    m_impl->onDrawRect(gfx::Rect(dirtyRect.origin.x,
-                                 dirtyRect.origin.y,
-                                 dirtyRect.size.width,
-                                 dirtyRect.size.height));
+  if (m_impl) {
+    float displayScale = self.window.backingScaleFactor;
+    m_impl->onDrawRect(gfx::Rect(dirtyRect.origin.x * displayScale,
+                                 dirtyRect.origin.y * displayScale,
+                                 dirtyRect.size.width * displayScale,
+                                 dirtyRect.size.height * displayScale));
+  }
 }
 
 - (void)keyDown:(NSEvent*)event
@@ -462,8 +465,9 @@ using namespace os;
 
   // Call OSXWindowImpl::onResize handler
   if (m_impl) {
-    m_impl->onResize(gfx::Size(newSize.width,
-                               newSize.height));
+    float displayScale = self.window.backingScaleFactor;
+    m_impl->onResize(gfx::Size(newSize.width * displayScale,
+                               newSize.height * displayScale));
   }
 }
 


### PR DESCRIPTION
On Retina displays view/window coordinates are logical points not pixels and `window.backingScaleFactor` represents how many pixels are covered by single coordinate point.

This change effectively makes LAF UI 2x smaller on Retina displays, but allows drawing at native Retina resolution.

A picture is worth a thousand words: (NOTE: Click on the image to see it on full 2x/Retina scale)
<img width="725" alt="image" src="https://user-images.githubusercontent.com/103067/86512566-9e67bf00-be03-11ea-9824-5a340080ebe9.png">

Picture above depicts Aseprite using 400% scale on Retina and using TTF font instead of bitmap font.

I understand this change may be completely irrelevant for most of the Aseprite users using default UI settings, but if you want to use TTF font this change actually makes all TTF fonts look crisp on macOS Retina displays. And I prefer to have TTF font on my Retina display rather than default bitmap font, that I find hard to read 🙄 

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Laf license, and agree to future changes to the
     licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by
     leaving the statement below. -->

I agree that my contributions are licensed under the Laf license, and agree to future changes to the licensing.
