### PR TITLE
Fix hue set function.

### DIFF
--- a/gfx/hsv.cpp
+++ b/gfx/hsv.cpp
@@ -22,11 +22,7 @@ Hsv::Hsv(double hue, double saturation, double value)
   : m_hue(hue)
   , m_saturation(base::clamp(saturation, 0.0, 1.0))
   , m_value(base::clamp(value, 0.0, 1.0))
-{
-  while (m_hue < 0.0)
-    m_hue += 360.0;
-  m_hue = std::fmod(m_hue, 360.0);
-}
+{ }
 
 // Reference: http://en.wikipedia.org/wiki/HSL_and_HSV
 Hsv::Hsv(const Rgb& rgb)

--- a/gfx/hsv.h
+++ b/gfx/hsv.h
@@ -49,7 +49,8 @@ public:
   int valueInt() const;
 
   void hue(double hue) {
-    m_hue = base::clamp(hue, 0.0, 360.0);
+    while (hue < 0.0) hue += 360.0;
+    m_hue = std::fmod(hue, 360.0);
   }
 
   void saturation(double saturation) {


### PR DESCRIPTION
Before this fix the hue set function clamped the hue value between 0 and 360, instead of convert the hue value to an equivalent angle between 0 and 360.

I agree that my contributions are licensed under the Laf license, and agree to future changes to the licensing.
