### PR TITLE
X11 error when glibc bounds checks enabled (main branch)

### DIFF
--- a/os/x11/xinput.h
+++ b/os/x11/xinput.h
@@ -159,7 +159,7 @@ public:
 
     ASSERT(XSelectExtensionEvent);
     XSelectExtensionEvent(display, window,
-                          &m_eventClasses[0],
+                          m_eventClasses.data(),
                           int(m_eventClasses.size()));
   }
 


### PR DESCRIPTION
See aseprite/aseprite#2755. Version of #27 for main branch.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Laf license, and agree to future changes to the
     licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by
     leaving the statement below. -->

I agree that my contributions are licensed under the Laf license, and agree to future changes to the licensing.
