### PR TITLE
Fix low performance over time with SetCursor (Fix Aseprite#2713)

### DIFF
--- a/os/win/window.cpp
+++ b/os/win/window.cpp
@@ -946,7 +946,7 @@ void WindowWin::onTabletAPIChange()
 
 bool WindowWin::setCursor(HCURSOR hcursor, bool custom)
 {
-  SetCursor(hcursor);
+  SetClassLongPtr(m_hwnd, GCLP_HCURSOR, (LONG_PTR)hcursor);
   if (m_hcursor && m_customHcursor)
     DestroyIcon(m_hcursor);
   m_hcursor = hcursor;


### PR DESCRIPTION
Instead of calling `SetCursor()`, swap the cursor reference on the window class. 
This aims to address https://github.com/aseprite/aseprite/issues/2713 Where `SetCursor()` results in decreased responsiveness as usage time progresses and persists even after closing and reopening the program.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Laf license, and agree to future changes to the
     licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by
     leaving the statement below. -->

I agree that my contributions are licensed under the Laf license, and agree to future changes to the licensing.
