### PR TITLE
Add Sha1 class methods digest() and size()

### DIFF
--- a/base/sha1.h
+++ b/base/sha1.h
@@ -33,6 +33,14 @@ namespace base {
       return m_digest[index];
     }
 
+    const uint8_t *digest() const {
+      return m_digest.data();
+    }
+
+    size_t size() const {
+      return m_digest.size();
+    }
+
   private:
     std::vector<uint8_t> m_digest;
   };


### PR DESCRIPTION
Adds the following methods to the Sha1 class:
- digest(): returns a pointer to the digest data.
- size(): returns the digest size.
