### PR TITLE
Force zero init of X11 class.

### DIFF
--- a/os/common/main.cpp
+++ b/os/common/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
   if (!app.init())
     return 1;
 #elif LAF_LINUX
-  os::X11 x11;
+  os::X11 x11();
 #endif
   return app_main(argc, argv);
 }


### PR DESCRIPTION
Running Aseprite batch mode (using `-b`) as part of a headless asset build process was causing it to segfault in `XInput::~XInput()` because `m_xi` was uninitialized. Forcing zero initialization fixes it.

I agree that my contributions are licensed under the Laf license, and agree to future changes to the licensing.