### PR TITLE
Fix crash on exit when color space is different from default system's

### DIFF
--- a/os/common/system.h
+++ b/os/common/system.h
@@ -37,7 +37,10 @@ namespace os {
 class CommonSystem : public System {
 public:
   CommonSystem() { }
-  ~CommonSystem() { set_instance(nullptr); }
+  ~CommonSystem() {
+    eventQueue()->clearEvents();
+    set_instance(nullptr);
+  }
 
   void setAppName(const std::string& appName) override { }
   void setAppMode(AppMode appMode) override { }

--- a/os/event_queue.h
+++ b/os/event_queue.h
@@ -23,6 +23,7 @@ namespace os {
     // limit the time of wait for the next event.
     virtual void getEvent(Event& ev, double timeout = kWithoutTimeout) = 0;
     virtual void queueEvent(const Event& ev) = 0;
+    virtual void clearEvents() = 0;
 
     // Deprecated old method. We should remove this line after some
     // releases. It's here to avoid calling getEvent(Event&, double)

--- a/os/win/event_queue.cpp
+++ b/os/win/event_queue.cpp
@@ -24,6 +24,11 @@ void EventQueueWin::queueEvent(const Event& ev)
   m_events.push(ev);
 }
 
+void EventQueueWin::clearEvents()
+{
+  m_events.clear();
+}
+
 void EventQueueWin::getEvent(Event& ev, double timeout)
 {
   base::tick_t untilTick = base::current_tick() + timeout*1000;

--- a/os/win/event_queue.h
+++ b/os/win/event_queue.h
@@ -21,6 +21,7 @@ class EventQueueWin : public EventQueue {
 public:
   void queueEvent(const Event& ev) override;
   void getEvent(Event& ev, double timeout) override;
+  void clearEvents();
 
 private:
   base::concurrent_queue<Event> m_events;


### PR DESCRIPTION
This PR fixes the situation where there are lingering events in the global `g_event` event queue that references already nullified window and thus trigger an ASSERT in the destructor of `WindowWin`. This usually happen when the color space is different from the system's default. The severity and technicality of this bug is discussed in the Aseprite repository [here](https://github.com/aseprite/aseprite/issues/3055).