### PR TITLE
Add copy_file function and its windows implementation

### DIFF
--- a/base/fs.h
+++ b/base/fs.h
@@ -26,6 +26,7 @@ namespace base {
   size_t file_size(const std::string& path);
 
   void move_file(const std::string& src, const std::string& dst);
+  void copy_file(const std::string& src, const std::string& dst, bool overwrite);
   void delete_file(const std::string& path);
 
   bool has_readonly_attr(const std::string& path);

--- a/base/fs_unix.h
+++ b/base/fs_unix.h
@@ -65,6 +65,11 @@ void move_file(const std::string& src, const std::string& dst)
     throw std::runtime_error("Error moving file");
 }
 
+void copy_file(const std::string& src, const std::string& dst, bool overwrite)
+{
+  throw std::runtime_error("Error copying file: unimplemented");
+}
+
 void delete_file(const std::string& path)
 {
   int result = unlink(path.c_str());

--- a/base/fs_win32.h
+++ b/base/fs_win32.h
@@ -49,6 +49,13 @@ void move_file(const std::string& src, const std::string& dst)
     throw Win32Exception("Error moving file");
 }
 
+void copy_file(const std::string& src, const std::string& dst, bool overwrite)
+{
+  BOOL result = ::CopyFile(from_utf8(src).c_str(), from_utf8(dst).c_str(), !overwrite);
+  if (result == 0)
+    throw Win32Exception("Error copying file");
+}
+
 void delete_file(const std::string& path)
 {
   BOOL result = ::DeleteFile(from_utf8(path).c_str());


### PR DESCRIPTION
Adds a new copy_file function. This PR adds only the Windows based implementation. Linux and macOS implementations throw exception.
