### PR TITLE
base::copy_file implementation

### DIFF
--- a/base/fs.h
+++ b/base/fs.h
@@ -25,9 +25,10 @@ namespace base {
 
   size_t file_size(const std::string& path);
 
-  void move_file(const std::string& src, const std::string& dst);
-  void copy_file(const std::string& src, const std::string& dst, bool overwrite);
-  void delete_file(const std::string& path);
+  bool move_file(const std::string& src, const std::string& dst);
+  bool copy_file(const std::string& src, const std::string& dst, bool overwrite);
+  // TODO: Change bool to enum Result?
+  bool delete_file(const std::string& path);
 
   bool has_readonly_attr(const std::string& path);
   void remove_readonly_attr(const std::string& path);


### PR DESCRIPTION
Hi!

This change, in short, implements base::copy_file function based on the idea of copying and pasting memory blocks.
I've also changed the functions (move, copy and delete file) that throw exceptions unnecessarily to return bool type.
(It needs clarify that I'm not an expert :sweat_smile:)