### PR TITLE
Add support for sorted parsing

### DIFF
--- a/base/program_options.cpp
+++ b/base/program_options.cpp
@@ -165,6 +165,15 @@ void ProgramOptions::parse(int argc, const char* argv[])
   }
 }
 
+void ProgramOptions::sortedParse(int argc, const char* argv[])
+{
+  parse(argc, argv);
+  std::stable_partition(
+    m_values.begin(), m_values.end(), [](const Value& value) {
+      return value.option() != nullptr;
+    });
+}
+
 void ProgramOptions::reset()
 {
   m_values.clear();

--- a/base/program_options.h
+++ b/base/program_options.h
@@ -96,6 +96,10 @@ namespace base {
     // Detects which options where specified in the command line.
     void parse(int argc, const char* argv[]);
 
+    // Like parse(...) but all values(e.g filenames) without related
+    // options are pushed to the end of list
+    void sortedParse(int argc, const char* argv[]);
+
     // Reset all option values/flags.
     void reset();
 


### PR DESCRIPTION
The rationale behind this proposal is a [bug](https://github.com/aseprite/aseprite/issues/3101#issue-1082657134) that resulted from the use of the [parse](https://github.com/aseprite/laf/blob/d47ccc7887a2d900e5297e032e8cf9fcfd75451c/base/program_options.cpp#L56) function [in Aseprite](https://github.com/aseprite/aseprite/blob/9e23d31d84a5bfdccc32aea065ffb60b02b57856/src/app/cli/app_options.cpp#L85). It so happened that the position of arguments is sensitive in some instances. For example, in cases where values without any associated options (e.g file names) come before some options, Aseprite opens the file(s), parse and process the opened file(s) before moving on to processing the other arguments. In [some of these cases](https://github.com/aseprite/aseprite/issues/3101#issuecomment-1018443032), the options provided via the CLI may be what is supposed to drive how the file is opened, parsed and processed. However, if the file is eagerly processed before the arguments, it results in some hard-to-debug bugs. This PR allows the user have two options:
- get access to the CLI values/options as-is
- move the option-less values to the end of "queue"

This second option delays the eagerness to open/process option-less values until all driving forces are properly taken care of. If, from Aseprite, we could have direct mutating access to the underlying values and options parsed, there would not have been a need for this PR but (rightly so) the interface exposed is immutable -- thus why I think this PR may be needed.

PS: I am not so sure the name of this function (`sortedParse`) is the right name for it, but as at the time of making this amendment, this is the only name I could think of.

ADDENDUM: According to this [comment](https://github.com/aseprite/aseprite/issues/3101#issuecomment-1021189235), this PR may not be necessary as the Aseprite opened issue isn't really a bug but a feature.