### PR TITLE
Error messages in fs_unix.h

### DIFF
--- a/base/fs_unix.h
+++ b/base/fs_unix.h
@@ -45,9 +45,8 @@ bool is_directory(const std::string& path)
 void make_directory(const std::string& path)
 {
   int result = mkdir(path.c_str(), 0777);
-  if (result < 0) {
-    // TODO add errno into the exception
-    throw std::runtime_error("Error creating directory");
+  if (result != 0) {
+    throw std::runtime_error("Error creating directory: " + std::string(strerror(errno)));
   }
 }
 
@@ -59,10 +58,9 @@ size_t file_size(const std::string& path)
 
 void move_file(const std::string& src, const std::string& dst)
 {
-  int result = std::rename(src.c_str(), dst.c_str());
+  int result = rename(src.c_str(), dst.c_str());
   if (result != 0)
-    // TODO add errno into the exception
-    throw std::runtime_error("Error moving file");
+    throw std::runtime_error("Error moving file: " + std::string(strerror(errno)));
 }
 
 void copy_file(const std::string& src, const std::string& dst, bool overwrite)
@@ -74,8 +72,7 @@ void delete_file(const std::string& path)
 {
   int result = unlink(path.c_str());
   if (result != 0)
-    // TODO add errno into the exception
-    throw std::runtime_error("Error deleting file");
+    throw std::runtime_error("Error deleting file: " + std::string(strerror(errno)));
 }
 
 bool has_readonly_attr(const std::string& path)
@@ -91,8 +88,7 @@ void remove_readonly_attr(const std::string& path)
   if (result == 0) {
     result = chmod(path.c_str(), sts.st_mode | S_IWUSR);
     if (result != 0)
-      // TODO add errno into the exception
-      throw std::runtime_error("Error removing read-only attribute");
+      throw std::runtime_error("Error removing read-only attribute: " + std::string(strerror(errno)));
   }
 }
 
@@ -113,10 +109,8 @@ Time get_modification_time(const std::string& path)
 void remove_directory(const std::string& path)
 {
   int result = rmdir(path.c_str());
-  if (result != 0) {
-    // TODO add errno into the exception
-    throw std::runtime_error("Error removing directory");
-  }
+  if (result != 0)
+    throw std::runtime_error("Error removing directory: " + std::string(strerror(errno)));
 }
 
 std::string get_current_path()


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Laf license, and agree to future changes to the
     licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by
     leaving the statement below. -->

I agree that my contributions are licensed under the Laf license, and agree to future changes to the licensing.

I have simply added `strerror` to each function which throws an error to get a more detailed error message.