### PR TITLE
Fix Windows build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# CMake output
+/build/

--- a/cmake/FindSkia.cmake
+++ b/cmake/FindSkia.cmake
@@ -28,13 +28,8 @@ endif()
 
 # Skia library
 find_library(SKIA_LIBRARY skia PATH "${SKIA_LIBRARY_DIR}")
-if(WIN32)
-  find_library(SKIA_OPENGL_LIBRARY opengl32)
-elseif(APPLE)
-  find_library(SKIA_OPENGL_LIBRARY OpenGL NAMES GL)
-else()
-  find_library(SKIA_OPENGL_LIBRARY opengl NAMES GL)
-endif()
+find_package(OpenGL REQUIRED)
+set(SKIA_OPENGL_LIBRARY OpenGL::GL)
 
 # SkShaper module + freetype + harfbuzz + zlib
 find_library(SKSHAPER_LIBRARY skshaper PATH "${SKIA_LIBRARY_DIR}")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -23,4 +23,10 @@ if(LAF_BACKEND STREQUAL "skia")
   laf_add_example(multiple_windows GUI)
   laf_add_example(panviewport GUI)
   laf_add_example(shader GUI)
+
+  if(MSVC)
+    # complextextlayout.cpp has wide strings. Specify UTF-8 charset explicitly for it.
+    # "/utf-8" is equivalent to "/source-charset:utf-8 /execution-charset:utf-8".
+    target_compile_options(complextextlayout PRIVATE "/utf-8")
+  endif()
 endif()


### PR DESCRIPTION
```
find_library() is not a proper way for finding OpenGL libraries.
On Windows, SKIA_OPENGL_LIBRARY got "SKIA_OPENGL_LIBRARY-NOTFOUND"
without using VS-Dev-CMD.

See discussions here:
    https://gitlab.kitware.com/cmake/cmake/-/issues/19804
    https://gitlab.kitware.com/cmake/cmake/-/issues/20226

Use find_package(OpenGL) and OpenGL::GL instead.
```
```
On Windows systems with non-English locales, the wide strings may cause
"Error C2001: Newline in constant".

2 solutions:
    Save the file with UTF-8 with BOM (byte-order mark).
    Specify UTF-8 charset for compilation. Used by this commit.

See discussions here:
    https://github.com/libusb/libusb/issues/207#issuecomment-288664124
```
I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT