### PR TITLE
Don't use pthread_detach() after pthread_join()

### DIFF
--- a/base/thread.cpp
+++ b/base/thread.cpp
@@ -55,8 +55,12 @@ thread::thread()
 
 thread::~thread()
 {
-  if (joinable())
+  if (joinable()) {
+#if LAF_WINDOWS
+    ::CloseHandle(m_native_handle);
+#endif  
     detach();
+  }
 }
 
 bool thread::joinable() const
@@ -69,6 +73,7 @@ void thread::join()
   if (joinable()) {
 #if LAF_WINDOWS
     ::WaitForSingleObject(m_native_handle, INFINITE);
+    ::CloseHandle(m_native_handle);
 #else
     ::pthread_join((pthread_t)m_native_handle, NULL);
 #endif
@@ -79,12 +84,7 @@ void thread::join()
 void thread::detach()
 {
   if (joinable()) {
-#if LAF_WINDOWS
-    ::CloseHandle(m_native_handle);
-    m_native_handle = (native_handle_type)0;
-#else
-    ::pthread_detach((pthread_t)m_native_handle);
-#endif
+    m_native_handle = (native_handle_type)NULL;
   }
 }
 


### PR DESCRIPTION
After pthread_join() all allocated to thread resources are freed, so pthread_detach() after pthread_join() will results in undefined behavior with SIGSERV on some libc implementations (like MUSL). According to pthread_detach(3), "Either pthread_join(3) or pthread_detach() should be called for each thread that an application creates".

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the MIT License. -->
<!-- Please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT
