### PR TITLE
Fix compilation on GCC13

### DIFF
--- a/base/file_content.h
+++ b/base/file_content.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "base/buffer.h"
+#include "base/ints.h"
 
 #include <cstdio>
 #include <string>

--- a/base/sha1.h
+++ b/base/sha1.h
@@ -11,6 +11,8 @@
 #include <vector>
 #include <string>
 
+#include "base/ints.h"
+
 extern "C" struct SHA1Context;
 
 namespace base {

--- a/base/sha1_rfc3174.h
+++ b/base/sha1_rfc3174.h
@@ -18,6 +18,8 @@
 #define BASE_SHA1_RFC3174_H_INCLUDED
 #pragma once
 
+#include "base/ints.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
GCC-13 changes internal cstdint includes, and now files that uses standard integer types should directly include cstdint header.

See: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes
Bug: https://bugs.gentoo.org/865117
Bug: https://bugs.gentoo.org/895616

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the MIT License. -->
<!-- Please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the MIT License.
