### PR TITLE
Flush X server's output buffer after an XMoveResizeWindow

### DIFF
--- a/os/x11/window.cpp
+++ b/os/x11/window.cpp
@@ -673,6 +673,7 @@ void WindowX11::setFrame(const gfx::Rect& bounds)
     m_window,
     rc.x, rc.y,
     rc.w, rc.h);
+  XFlush(m_display);
 }
 
 gfx::Rect WindowX11::contentRect() const


### PR DESCRIPTION
This prevents getting stale windows geometry data when calling contentRect. 

Fixes the situation described in this comment: https://github.com/aseprite/aseprite/pull/3759#issuecomment-1481697355
