### PR TITLE
Fix rounded rectangle of GraphicsContext is a little off at the bottom side (fix #3795)

### DIFF
--- a/gfx/path_skia.h
+++ b/gfx/path_skia.h
@@ -72,7 +72,7 @@ namespace gfx {
     }
 
     Path& roundedRect(const Rect& rc, float rx, float ry) {
-      m_skPath.addRoundRect(SkRect::MakeXYWH(rc.x, rc.y, rc.w, rc.h), rx, ry);
+      m_skPath.addRoundRect(SkRect::MakeXYWH(rc.x + 0.5, rc.y + 0.5, rc.w, rc.h), rx, ry);
       return *this;
     }
 


### PR DESCRIPTION
This correction improves the symmetrical appearance of the corners.

However, some issues remains even with this fix:
- The size of input rectangle doesn't match with the output rounded rectangle bounds
- In some cases the rounded rectangle has non symmetrical corners.
- In some cases, some pixels are missing in the stroke of the corners.

Fix https://github.com/aseprite/aseprite/issues/3795