### PR TITLE
Allow \ in file names in unix

### DIFF
--- a/base/fs.cpp
+++ b/base/fs.cpp
@@ -73,7 +73,10 @@ std::string get_absolute_path(const std::string& filename)
 
 bool is_path_separator(std::string::value_type chr)
 {
+#if LAF_WINDOWS
   return (chr == '\\' || chr == '/');
+#endif
+  return (chr == '/');
 }
 
 std::string get_file_path(const std::string& filename)


### PR DESCRIPTION
fix [aseprite/aseprite#3989](https://github.com/aseprite/aseprite/issues/3936)

Allows to pick files with \ in files names in Linux.
Should also work with MacOS.

I agree that my contributions are licensed under the MIT License.

