### PR TITLE
Fix: Drawing using a keyboard key on X11

### DIFF
--- a/os/x11/window.cpp
+++ b/os/x11/window.cpp
@@ -1042,7 +1042,19 @@ void WindowX11::processX11Event(XEvent& event)
         KEY_TRACE("Xutf8LookupString %s\n", &buf[0]);
       }
 
-      // Key event used by the input method (e.g. when the user
+      // Check if the key has been pressed, 
+      // and if yes - check if it's the same one key
+      // as in the previous event.  If it's the same one
+      // - it means key is being held, so set repeat to 1.
+      if (event.type == KeyPress) {
+        if (keysym == m_pressedKeySym)
+          ev.setRepeat(1);
+        m_pressedKeySym = keysym;
+      }
+      else
+        m_pressedKeySym = 0;
+
+      // Key event used by the input method (e.g. when the users
       // presses a dead key).
       if (XFilterEvent(&event, m_window))
         break;

--- a/os/x11/window.h
+++ b/os/x11/window.h
@@ -128,6 +128,8 @@ private:
   bool m_resizable = false;
   bool m_transparent = false;
 
+  KeySym m_pressedKeySym = 0;
+
   // Double-click info
   Event::MouseButton m_doubleClickButton;
   base::tick_t m_doubleClickTick;


### PR DESCRIPTION
As spoken in https://github.com/aseprite/aseprite/pull/4063 - currently, if we try to bind a key to mouse trigger button and we will try to draw with it - after a longer period of holding the key, drawing will stop and will try to draw continously with short breaks.

This is caused because we never set repeat count inside the event that we generate from the event that comes from X Window System.

Repeat count is being properly checked in doc_view.cpp:onProcessMessage method, although it always equals 0 - thus allowing for the key event to be converted to mouse event, and at the same time interpreting (and queueing) it as a mouse event.

Solution for that is to simply check if the previous key event that came was KeyPress, and if it is currently pressed. If yes - it means that user never pushed the key down, thus set repeat count to 1. Otherwise, if the previous key event is KeyRelease for example - it means user has pushed the key down, thus repeat count on the current event can be set to 0.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the MIT License. -->
<!-- Please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT
