### PR TITLE
Fix: Drawing using keys on Windows

### DIFF
--- a/os/win/window.cpp
+++ b/os/win/window.cpp
@@ -1679,7 +1679,13 @@ LRESULT WindowWin::wndProc(UINT msg, WPARAM wparam, LPARAM lparam)
       ev.setModifiers(get_modifiers_from_last_win32_message());
       ev.setScancode(ourScancode);
       ev.setUnicodeChar(0);
-      ev.setRepeat(std::max(0, int((lparam & 0xffff)-1)));
+
+      // if the last registered key scancode is equal to current
+      // scancode, it means the same event came, thus the key
+      // is being held down, so set repeat to 1
+      if (ourScancode == m_pressedKeyScancode)
+        ev.setRepeat(1);
+      m_pressedKeyScancode = ourScancode;
 
       KEY_TRACE("KEYDOWN vk=%d scancode=%d->%d modifiers=%d\n",
                 vk, scancode, ev.scancode(), ev.modifiers());
@@ -1727,6 +1733,10 @@ LRESULT WindowWin::wndProc(UINT msg, WPARAM wparam, LPARAM lparam)
       ev.setUnicodeChar(0);
       ev.setRepeat(std::max(0, int((lparam & 0xffff)-1)));
       queueEvent(ev);
+
+
+      // set keyscancode to 0 (kKeyNil), since the key has been pressed down
+      m_pressedKeyScancode = KeyScancode::kKeyNil;
 
       // TODO If we use native menus, this message should be given
       // to the DefWindowProc() in some cases (e.g. F10 or Alt keys)

--- a/os/win/window.h
+++ b/os/win/window.h
@@ -138,6 +138,7 @@ namespace os {
     gfx::Rect m_restoredFrame;
 #endif
 
+    KeyScancode m_pressedKeyScancode = KeyScancode::kKeyNil;
     int m_scale;
     bool m_isCreated;
     // Since Windows Vista, it looks like Microsoft decided to change


### PR DESCRIPTION
This patch is essentially the same implementation as in https://github.com/aseprite/laf/pull/69 - now the repeat count is being set correctly if we press the same event twice in a row, resulting in key events binded to mouse events being converted properly.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the MIT License. -->
<!-- Please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT
