### PR TITLE
Flush pending events before opening pipe to zenity

### DIFF
--- a/os/x11/native_dialogs.cpp
+++ b/os/x11/native_dialogs.cpp
@@ -16,6 +16,7 @@
 #include "base/replace_string.h"
 #include "base/split_string.h"
 #include "os/common/file_dialog.h"
+#include "os/x11/x11.h"
 
 #include <cstdio>              // popen/pclose()
 #include <cstring>
@@ -139,6 +140,9 @@ public:
         // between the given "parent" argument in this show() function
         // and the created window by the utility.
 
+        // Flushes pending events to the X Server, so that input does not
+        // get stuck when opening a pipe to zenity.
+        XFlush(X11::instance()->display());
         // Here we run the command and get a handle to read its
         // stdout.
         FILE* f = popen(cmd.c_str(), "r");


### PR DESCRIPTION
Mouse clicks are ignored when we open a pipe to zenity without flushing the pending X11 events first because popen stalls aseprite execution until we selected a file.
This is in response to https://github.com/aseprite/aseprite/issues/3974

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the MIT License. -->
<!-- Please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT
