### PR TITLE
Fix 'is_process_running' returns an incorrect 'true' when process 'pid' exists, but whose process does not belong to the current application.

### DIFF
--- a/base/process.cpp
+++ b/base/process.cpp
@@ -26,6 +26,11 @@
   #include <string.h>
 #endif
 
+#if LAF_LINUX
+  #include "base/fs.h"
+  #include <stdlib.h>
+  #include <cstring>
+#endif
 namespace base {
 
 #if LAF_WINDOWS
@@ -107,12 +112,22 @@ pid get_current_process_id()
 
 bool is_process_running(pid pid, const char* pname)
 {
-  return (kill(pid, 0) == 0);
+  char path[128];
+  memset(path, 0, 128);
+  sprintf(path, "/proc/%d/exe", pid);
+  char* exepath = realpath(path, nullptr);
+  if (!exepath)
+    return false;
+
+  auto exename = base::get_file_name(exepath);
+  free(exepath);
+
+  return exename == std::string(pname);
 }
 
 bool is_process_running(pid pid)
 {
-  return is_process_running(pid, "");
+  return (kill(pid, 0) == 0);
 }
 
 #endif

--- a/base/process.cpp
+++ b/base/process.cpp
@@ -1,5 +1,5 @@
 // LAF Base Library
-// Copyright (c) 2021 Igara Studio S.A.
+// Copyright (c) 2021-2024 Igara Studio S.A.
 // Copyright (c) 2015-2016 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -13,10 +13,17 @@
 
 #if LAF_WINDOWS
   #include <windows.h>
+  #include <iostream>
+  #include <tlhelp32.h>
 #else
   #include <signal.h>
   #include <sys/types.h>
   #include <unistd.h>
+#endif
+
+#if LAF_MACOS
+  #include <libproc.h>
+  #include <string.h>
 #endif
 
 namespace base {
@@ -26,6 +33,33 @@ namespace base {
 pid get_current_process_id()
 {
   return (pid)GetCurrentProcessId();
+}
+
+bool is_process_running(pid pid, const char* pname)
+{
+  bool running = false;
+  HANDLE handle = CreateToolhelp32Snapshot(TH32CS_SNAPALL, 0);
+  if (handle) {
+    PROCESSENTRY32 pe;
+    pe.dwSize = sizeof(PROCESSENTRY32);
+    if (Process32First(handle, &pe)) {
+      do {
+        char buf[64];
+        wcstombs(buf, pe.szExeFile, 64);
+        std::string str(buf);
+        for (char& c : str) {
+          c = tolower(c);
+        }
+        if (pe.th32ProcessID == pid &&
+            str == pname) {
+          running = true;
+        }
+      } while (Process32Next(handle, &pe));
+    }
+    CloseHandle(handle);
+  }
+
+  return running;
 }
 
 bool is_process_running(pid pid)
@@ -44,16 +78,41 @@ bool is_process_running(pid pid)
   return running;
 }
 
-#else // !LAF_WINDOWS
+#elif LAF_MACOS
 
 pid get_current_process_id()
 {
   return (pid)getpid();
 }
 
+bool is_process_running(pid pid, const char* pname)
+{
+  struct proc_bsdinfo process;
+  proc_pidinfo(pid, PROC_PIDTBSDINFO, 0,
+               &process, PROC_PIDTBSDINFO_SIZE);
+  return (strcmp(pname, process.pbi_name) == 0);
+}
+
 bool is_process_running(pid pid)
 {
   return (kill(pid, 0) == 0);
+}
+
+#elif LAF_LINUX
+
+pid get_current_process_id()
+{
+  return (pid)getpid();
+}
+
+bool is_process_running(pid pid, const char* pname)
+{
+  return (kill(pid, 0) == 0);
+}
+
+bool is_process_running(pid pid)
+{
+  return is_process_running(pid, "");
 }
 
 #endif

--- a/base/process.h
+++ b/base/process.h
@@ -1,4 +1,5 @@
 // LAF Base Library
+// Copyright (c) 2023-2024 Igara Studio S.A.
 // Copyright (c) 2015-2016 David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -15,6 +16,8 @@ namespace base {
   typedef uint32_t pid;
 
   pid get_current_process_id();
+
+  bool is_process_running(pid pid, const char* pname);
 
   bool is_process_running(pid pid);
 

--- a/base/process.h
+++ b/base/process.h
@@ -11,14 +11,20 @@
 
 #include "base/ints.h"
 
+#include <string>
+
 namespace base {
 
   typedef uint32_t pid;
 
   pid get_current_process_id();
 
-  bool is_process_running(pid pid, const char* pname);
+  std::string get_process_name(pid pid);
 
+  bool is_process_running(pid pid, std::string currentProcessName);
+
+  // Declaration to avoid errors during testing of Github actions
+  // TO DO: remove function after the implementation of PR aseprite/aseprite#4266
   bool is_process_running(pid pid);
 
 } // namespace base


### PR DESCRIPTION
Windows part not solved yet.
Linux not tested yet.

The current fix on all platforms might make aseprite/aseprite#4130 unnecessary.