### PR TITLE
Add mouse coordinates to os::Event::DropFiles event indicating the point where the drop of files took place on the target window

### DIFF
--- a/examples/allevents.cpp
+++ b/examples/allevents.cpp
@@ -40,7 +40,9 @@ public:
         break;
 
       case os::Event::DropFiles:
-        logLine("DropFiles files={");
+        logLine("DropFiles pos=%d,%d files={",
+                ev.position().x,
+                ev.position().y);
         for (const auto& file : ev.files()) {
           logLine("  \"%s\"", file.c_str());
         }

--- a/os/osx/view.mm
+++ b/os/osx/view.mm
@@ -661,6 +661,10 @@ using namespace os;
     NSArray* filenames = [pasteboard propertyListForType:NSFilenamesPboardType];
 
     os::Event ev = generate_drop_files_from_nsarray(filenames);
+    NSRect contentRect = [sender.draggingDestinationWindow contentRectForFrameRect: sender.draggingDestinationWindow.frame];
+    ev.setPosition(gfx::Point(
+      sender.draggingLocation.x,
+      contentRect.size.height - sender.draggingLocation.y));
     [self queueEvent:ev];
     return YES;
   }

--- a/os/win/window.cpp
+++ b/os/win/window.cpp
@@ -1751,11 +1751,15 @@ LRESULT WindowWin::wndProc(UINT msg, WPARAM wparam, LPARAM lparam)
         }
       }
 
-      DragFinish(hdrop);
-
       Event ev;
       ev.setType(Event::DropFiles);
       ev.setFiles(files);
+      POINT pos;
+      if (DragQueryPoint(hdrop, &pos))
+        ev.setPosition(gfx::Point(pos.x, pos.y));
+
+      DragFinish(hdrop);
+
       queueEvent(ev);
       break;
     }

--- a/os/x11/window.cpp
+++ b/os/x11/window.cpp
@@ -105,6 +105,7 @@ Atom XdndFinished = 0;
 Atom XdndSelection = 0;
 Atom URI_LIST = 0;
 ::Window g_dndSource = 0;
+gfx::Point g_dndPosition;
 
 // See https://bugs.freedesktop.org/show_bug.cgi?id=12871 for more
 // information, it looks like the official way to convert a X Window
@@ -1218,6 +1219,9 @@ void WindowX11::processX11Event(XEvent& event)
       }
       else if (event.xclient.message_type == XdndPosition) {
         auto sourceWindow = (::Window)event.xclient.data.l[0];
+        // Save the latest mouse position reported by the source window
+        g_dndPosition.x = event.xclient.data.l[2] >> 16;
+        g_dndPosition.y = event.xclient.data.l[2] & 0xFFFF;
 
         // TODO Ask to the library user if we can drop and the action
         //      that will take place
@@ -1282,6 +1286,9 @@ void WindowX11::processX11Event(XEvent& event)
               os::Event ev;
               ev.setType(os::Event::DropFiles);
               ev.setFiles(files);
+              // Mouse position is relative to the root window, so
+              // we make it relative to the content rect.
+              ev.setPosition(g_dndPosition - contentRect().origin());
               queueEvent(ev);
 
               successful = true;


### PR DESCRIPTION
Implements pending work needed for https://github.com/aseprite/aseprite/issues/131