### PR TITLE
Add removeEscapeCharFromText() function to 'base::string'

### DIFF
--- a/base/string.cpp
+++ b/base/string.cpp
@@ -69,6 +69,24 @@ std::string string_to_upper(const std::string& original)
   return to_utf8(result);
 }
 
+std::string removeEscapeCharFromText(const std::string& original,
+                                     const int escapeChar)
+{
+  std::wstring newText; // wstring is used to properly push_back() multibyte chars
+  newText.reserve(original.size());
+
+  utf8_decode decode(original);
+  while (int chr = decode.next()) {
+    if (chr == escapeChar) {
+      chr = decode.next();
+      if (!chr)
+        break;    // Ill-formed string (it ends with escape character)
+    }
+    newText.push_back(chr);
+  }
+  return to_utf8(newText);
+}
+
 #ifdef LAF_WINDOWS
 
 std::string to_utf8(const wchar_t* src, const size_t n)

--- a/base/string.h
+++ b/base/string.h
@@ -20,7 +20,9 @@ namespace base {
 
   std::string string_to_lower(const std::string& original);
   std::string string_to_upper(const std::string& original);
-
+  std::string removeEscapeCharFromText(const std::string& original,
+                                       const int escapeChar);
+  
   std::string to_utf8(const wchar_t* src, size_t n);
 
   inline std::string to_utf8(const std::wstring& widestring) {


### PR DESCRIPTION
This addition is needed in the PR: https://github.com/aseprite/aseprite/pull/4453  to solve issue: https://github.com/aseprite/aseprite/issues/4387 (Duplicate shortcut key configuration items in Keyboard shortcuts)