### PR TITLE
[osx] Fix events handling

### DIFF
--- a/os/osx/event_queue.h
+++ b/os/osx/event_queue.h
@@ -13,8 +13,6 @@
 #include "os/event.h"
 #include "os/event_queue.h"
 
-#include <atomic>
-
 namespace os {
 
 class EventQueueOSX : public EventQueue {
@@ -29,7 +27,8 @@ private:
   void wakeUpQueue();
 
   base::concurrent_queue<Event> m_events;
-  std::atomic<bool> m_sleeping;
+  mutable std::mutex m_mutex;
+  bool m_sleeping;
 };
 
 using EventQueueImpl = EventQueueOSX;

--- a/os/osx/event_queue.h
+++ b/os/osx/event_queue.h
@@ -9,9 +9,11 @@
 #define OS_OSX_EVENT_QUEUE_INCLUDED
 #pragma once
 
-#include "base/concurrent_queue.h"
 #include "os/event.h"
 #include "os/event_queue.h"
+
+#include <mutex>
+#include <queue>
 
 namespace os {
 
@@ -26,7 +28,7 @@ public:
 private:
   void wakeUpQueue();
 
-  base::concurrent_queue<Event> m_events;
+  std::deque<Event> m_events;
   mutable std::mutex m_mutex;
   bool m_sleeping;
 };


### PR DESCRIPTION
Fix #89

This is the second attempt to fix the issue. This time I just used a mutex to avoid the issue and kept almost all the code in its original form. I didn't use the concurrent queue mutex to avoid polluting its API and because I'm not sure it would be enough. Hence, if at the end the concurrent queue mutex is not going to be used I believe that we should replace that queue for a regular std::deque.