### PR TITLE
New Paint::SrcEdges to enable mipmaps

### DIFF
--- a/os/paint.h
+++ b/os/paint.h
@@ -1,5 +1,5 @@
 // LAF OS Library
-// Copyright (c) 2019-2022  Igara Studio S.A.
+// Copyright (c) 2019-2024  Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -54,6 +54,18 @@ namespace os {
       Stroke,
       StrokeAndFill,
     };
+
+    // Same as SkCanvas::SrcRectConstraint
+    enum SrcEdges {
+      Strict, // Sample only inside bounds, is slower (don't use mipmaps)
+      Fast,   // Sample outside bounds, is faster (use mipmaps)
+    };
+
+    SrcEdges srcEdges() const { return m_srcEdges; }
+    void srcEdges(const SrcEdges srcEdges) { m_srcEdges = srcEdges; }
+
+  private:
+    SrcEdges m_srcEdges = SrcEdges::Strict;
   };
 
 };

--- a/os/skia/skia_surface.h
+++ b/os/skia/skia_surface.h
@@ -18,6 +18,7 @@
 #include "os/surface_format.h"
 
 #include "include/core/SkBitmap.h"
+#include "include/core/SkCanvas.h"
 #include "include/core/SkColorType.h"
 #include "include/core/SkPaint.h"
 #include "include/core/SkSurface.h"
@@ -121,19 +122,22 @@ private:
     const Surface* src,
     const gfx::Clip& clip,
     const SkSamplingOptions& sampling,
-    const SkPaint& paint);
+    const SkPaint& paint,
+    SkCanvas::SrcRectConstraint constraint);
   void skDrawSurface(
     const Surface* src,
     const gfx::Rect& srcRect,
     const gfx::Rect& dstRect,
     const SkSamplingOptions& sampling,
-    const SkPaint& paint);
+    const SkPaint& paint,
+    SkCanvas::SrcRectConstraint constraint);
   void skDrawSurface(
     const SkiaSurface* src,
     const SkRect& srcRect,
     const SkRect& dstRect,
     const SkSamplingOptions& sampling,
-    const SkPaint& paint);
+    const SkPaint& paint,
+    SkCanvas::SrcRectConstraint constraint);
 
 #if SK_SUPPORT_GPU
   const SkImage* getOrCreateTextureImage() const;


### PR DESCRIPTION
This can be used to fix:

  https://github.com/aseprite/aseprite/issues/4317

From SkCanvas::SrcRectConstraint docs:

  "SrcRectConstraint controls the behavior at the edge of source
   SkRect, provided to drawImageRect() when there is any filtering. If
   kStrict is set, then extra code is used to ensure it nevers samples
   outside of the src-rect. kStrict_SrcRectConstraint disables the
   use of mipmaps."

We were always using kStrict, which disabled mipmaps.

