### PR TITLE
Get desktop bounds correctly on X11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get install -y \
             libc++-dev libc++abi-dev \
             libpixman-1-dev libfreetype6-dev libharfbuzz-dev zlib1g-dev \
-            libx11-dev libxcursor-dev libxi-dev libgl1-mesa-dev
+            libx11-dev libxcursor-dev libxi-dev libxrandr-dev libgl1-mesa-dev
           if [[ "${{ matrix.backend }}" == "skia" ]] ; then
             wget https://github.com/aseprite/skia/releases/download/m102-861e4743af/Skia-Linux-Release-x64-libc++.zip
             unzip Skia-Linux-Release-x64-libc++.zip -d skia

--- a/os/CMakeLists.txt
+++ b/os/CMakeLists.txt
@@ -51,7 +51,9 @@ else()
     x11/system.cpp
     x11/window.cpp
     x11/x11.cpp
-    x11/xinput.cpp)
+    x11/xinput.cpp
+    x11/monitor.cpp
+    x11/monitor.h)
 endif()
 
 ######################################################################
@@ -146,7 +148,10 @@ else()
   if(NOT X11_Xinput_FOUND)
     message(FATAL_ERROR "Xinput library not found")
   endif()
-  list(APPEND LAF_OS_PLATFORM_LIBS ${X11_Xcursor_LIB})
+  if(NOT X11_Xrandr_FOUND)
+    message(FATAL_ERROR "Xrandr library not found")
+  endif()
+  list(APPEND LAF_OS_PLATFORM_LIBS ${X11_Xcursor_LIB} ${X11_Xrandr_LIB})
 
   check_library_exists(X11 XOpenIM "${X11_LIB_SEARCH_PATH}" XIM_FOUND)
 

--- a/os/x11/monitor.cpp
+++ b/os/x11/monitor.cpp
@@ -1,6 +1,12 @@
-#include "monitor.h"
+#include "os/x11/monitor.h"
+#include "gfx/rect.h"
+#include "os/ref.h"
+#include "os/screen.h"
 #include "os/x11/x11.h"
+#include "os/x11/screen.h"
 
+#include <climits>
+#include <algorithm>
 #include <X11/extensions/Xrandr.h>
 
 namespace os {
@@ -18,7 +24,43 @@ MonitorsX11::MonitorsX11()
 
 int MonitorsX11::numMonitors() const { return m_numMonitors; }
 
-const XRRMonitorInfo& MonitorsX11::monitor(int monitorNum) const { return m_monitors.get()[monitorNum]; }
+const XRRMonitorInfo& MonitorsX11::monitorInfo(int monitorNum) const { return m_monitors.get()[monitorNum]; }
+
+// searches for the monitor containing the most area of the window
+ScreenRef MonitorsX11::nearestMonitorOf(const gfx::Rect& frame) const
+{
+  ScreenRef candidate = nullptr;
+  int most_area = INT_MIN;
+
+  for (int nmonitor=0; nmonitor<m_numMonitors; nmonitor++) {
+    ScreenRef monitor = os::make_ref<ScreenX11>(nmonitor);
+
+    const gfx::Rect& bounds = monitor->bounds();
+    gfx::Rect segment(frame);
+    if (segment.x < bounds.x) {
+      segment.w = std::max(0, segment.w - (bounds.x-segment.x));
+      segment.x = bounds.x;
+    }
+    if (segment.x2() > bounds.x2()) {
+      segment.w = std::max(0, segment.w - (segment.x2()-bounds.x2()));
+    }
+    if (segment.y < bounds.y) {
+      segment.h = std::max(0, segment.h - (bounds.y-segment.y));
+      segment.y = bounds.y;
+    }
+    if (segment.y2() > bounds.y2()) {
+      segment.h = std::max(0, segment.h - (segment.y2()-bounds.y2()));
+    }
+
+    int area = segment.w*segment.h;
+    if (area > most_area) {
+      candidate = monitor;
+      most_area = area;
+    }
+  }
+
+  return candidate;
+}
 
 } // namespace os
 

--- a/os/x11/monitor.cpp
+++ b/os/x11/monitor.cpp
@@ -1,0 +1,24 @@
+#include "monitor.h"
+#include "os/x11/x11.h"
+
+#include <X11/extensions/Xrandr.h>
+
+namespace os {
+
+MonitorsX11::MonitorsX11()
+{
+  auto x11display = X11::instance()->display();
+
+  int numMonitors;
+  XRRMonitorInfo* monitors = XRRGetMonitors(x11display, XDefaultRootWindow(x11display), false, &numMonitors);
+
+  m_numMonitors = numMonitors;
+  m_monitors = unique_monitors_ptr(monitors);
+}
+
+int MonitorsX11::numMonitors() const { return m_numMonitors; }
+
+const XRRMonitorInfo& MonitorsX11::monitor(int monitorNum) const { return m_monitors.get()[monitorNum]; }
+
+} // namespace os
+

--- a/os/x11/monitor.h
+++ b/os/x11/monitor.h
@@ -2,8 +2,11 @@
 #define MONITOR_H
 #pragma once
 
-#include <memory>
+#include "gfx/fwd.h"
+#include "os/screen.h"
+
 #include <X11/extensions/Xrandr.h>
+#include <memory>
 
 namespace os {
 
@@ -16,8 +19,11 @@ typedef std::unique_ptr<XRRMonitorInfo, MonitorCloser> unique_monitors_ptr;
 class MonitorsX11 {
 public:
   MonitorsX11();
+
   int numMonitors() const;
-  const XRRMonitorInfo& monitor(int monitorNum) const;
+  const XRRMonitorInfo& monitorInfo(int monitorNum) const;
+
+  ScreenRef nearestMonitorOf(const gfx::Rect& frame) const;
 
 private:
   int m_numMonitors;

--- a/os/x11/monitor.h
+++ b/os/x11/monitor.h
@@ -1,0 +1,29 @@
+#ifndef MONITOR_H
+#define MONITOR_H
+#pragma once
+
+#include <memory>
+#include <X11/extensions/Xrandr.h>
+
+namespace os {
+
+struct MonitorCloser {
+  void operator()(XRRMonitorInfo* monitors) const noexcept { XRRFreeMonitors(monitors); }
+};
+
+typedef std::unique_ptr<XRRMonitorInfo, MonitorCloser> unique_monitors_ptr;
+
+class MonitorsX11 {
+public:
+  MonitorsX11();
+  int numMonitors() const;
+  const XRRMonitorInfo& monitor(int monitorNum) const;
+
+private:
+  int m_numMonitors;
+  unique_monitors_ptr m_monitors;
+};
+
+} // namespace os
+
+#endif //MONITOR_H

--- a/os/x11/screen.h
+++ b/os/x11/screen.h
@@ -11,6 +11,7 @@
 #include "os/screen.h"
 #include "os/x11/monitor.h"
 #include "os/x11/x11.h"
+#include "os/system.h"
 
 #include <X11/extensions/Xrandr.h>
 
@@ -20,7 +21,7 @@ class ScreenX11 : public Screen {
 public:
   ScreenX11(int monitorNum) : m_monitorNum(monitorNum) {
     MonitorsX11* monitors = X11::instance()->monitors();
-    const XRRMonitorInfo& monitor = monitors->monitor(monitorNum);
+    const XRRMonitorInfo& monitor = monitors->monitorInfo(monitorNum);
 
     m_bounds.x = monitor.x;
     m_bounds.y = monitor.y;

--- a/os/x11/screen.h
+++ b/os/x11/screen.h
@@ -9,51 +9,33 @@
 #pragma once
 
 #include "os/screen.h"
+#include "os/x11/monitor.h"
 #include "os/x11/x11.h"
 
-#include <X11/Xatom.h>
+#include <X11/extensions/Xrandr.h>
 
 namespace os {
 
 class ScreenX11 : public Screen {
 public:
-  ScreenX11(int screen) {
-    auto x11 = X11::instance();
-    auto x11display = x11->display();
+  ScreenX11(int monitorNum) : m_monitorNum(monitorNum) {
+    MonitorsX11* monitors = X11::instance()->monitors();
+    const XRRMonitorInfo& monitor = monitors->monitor(monitorNum);
 
-    m_bounds.w = XDisplayWidth(x11display, screen);
-    m_bounds.h = XDisplayHeight(x11display, screen);
+    m_bounds.x = monitor.x;
+    m_bounds.y = monitor.y;
+    m_bounds.w = monitor.width;
+    m_bounds.h = monitor.height;
+    // Xorg doesn't really provide a way to find workarea per monitor :/
+    m_workarea.x = monitor.x;
+    m_workarea.y = monitor.y;
+    m_workarea.w = monitor.width;
+    m_workarea.h = monitor.height;
 
-    ::Window root = XDefaultRootWindow(x11display);
-    Atom _NET_WORKAREA = XInternAtom(x11display, "_NET_WORKAREA", False);
-
-    Atom actual_type;
-    int actual_format;
-    unsigned long nitems;
-    unsigned long bytes_after;
-    unsigned long* prop;
-
-    int res = XGetWindowProperty(x11display, root,
-                                 _NET_WORKAREA,
-                                 0, 4,
-                                 False, XA_CARDINAL,
-                                 &actual_type, &actual_format,
-                                 &nitems, &bytes_after,
-                                 (unsigned char**)&prop);
-    if (res == Success && nitems == 4) {
-      m_workarea.x = prop[0];
-      m_workarea.y = prop[1];
-      m_workarea.w = prop[2];
-      m_workarea.h = prop[3];
-      XFree(prop);
-    }
-    else {
-      m_workarea = m_bounds;
-    }
+    m_isPrimary = monitor.primary;
   }
-  bool isMainScreen() const override {
-    return (m_screen == XDefaultScreen(X11::instance()->display()));
-  }
+
+  bool isMainScreen() const override { return m_isPrimary; }
   gfx::Rect bounds() const override { return m_bounds; }
   gfx::Rect workarea() const override { return m_workarea; }
   os::ColorSpaceRef colorSpace() const override {
@@ -61,10 +43,11 @@ public:
     return os::instance()->makeColorSpace(gfx::ColorSpace::MakeSRGB());
   }
   void* nativeHandle() const override {
-    return reinterpret_cast<void*>(m_screen);
+    return reinterpret_cast<void*>(m_monitorNum);
   }
 private:
-  int m_screen;
+  int m_monitorNum;
+  bool m_isPrimary;
   gfx::Rect m_bounds;
   gfx::Rect m_workarea;
 };

--- a/os/x11/system.h
+++ b/os/x11/system.h
@@ -14,7 +14,9 @@
 #include "os/x11/screen.h"
 #include "os/x11/x11.h"
 
+#include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <X11/extensions/Xrandr.h>
 
 namespace os {
 
@@ -25,6 +27,7 @@ public:
   void setTabletOptions(const TabletOptions& options) override {
     m_tabletOptions = options;
   }
+
   TabletOptions tabletOptions() const override {
     return m_tabletOptions;
   }
@@ -81,14 +84,23 @@ public:
   }
 
   ScreenRef mainScreen() override {
-    return make_ref<ScreenX11>(
-      XDefaultScreen(X11::instance()->display()));
+    MonitorsX11* monitors = X11::instance()->monitors();
+    const int numMonitors = monitors->numMonitors();
+
+    // we have to search for the primary monitor
+    for (int monitor=0; monitor<numMonitors; monitor++) {
+      if (monitors->monitor(monitor).primary) {
+        return make_ref<ScreenX11>(monitor);
+      }
+    }
+
+    return nullptr;
   }
 
   void listScreens(ScreenList& list) override {
-    const int nscreen = XScreenCount(X11::instance()->display());
-    for (int screen=0; screen<nscreen; screen++)
-      list.push_back(make_ref<ScreenX11>(screen));
+    const int numMonitors = X11::instance()->monitors()->numMonitors();
+    for (int monitor=0; monitor<numMonitors; monitor++)
+      list.push_back(make_ref<ScreenX11>(monitor));
   }
 
 private:

--- a/os/x11/system.h
+++ b/os/x11/system.h
@@ -89,7 +89,7 @@ public:
 
     // we have to search for the primary monitor
     for (int monitor=0; monitor<numMonitors; monitor++) {
-      if (monitors->monitor(monitor).primary) {
+      if (monitors->monitorInfo(monitor).primary) {
         return make_ref<ScreenX11>(monitor);
       }
     }

--- a/os/x11/window.cpp
+++ b/os/x11/window.cpp
@@ -447,7 +447,7 @@ WindowX11::~WindowX11()
 
 os::ScreenRef WindowX11::screen() const
 {
-  return os::make_ref<ScreenX11>(DefaultScreen(m_display));
+  return os::instance()->mainScreen();
 }
 
 os::ColorSpaceRef WindowX11::colorSpace() const

--- a/os/x11/window.cpp
+++ b/os/x11/window.cpp
@@ -447,7 +447,11 @@ WindowX11::~WindowX11()
 
 os::ScreenRef WindowX11::screen() const
 {
-  return os::instance()->mainScreen();
+  ScreenRef nearestMonitor = X11::instance()->monitors()->nearestMonitorOf(frame());
+  if (nearestMonitor)
+    return nearestMonitor;
+  else
+    return os::instance()->mainScreen();
 }
 
 os::ColorSpaceRef WindowX11::colorSpace() const

--- a/os/x11/x11.cpp
+++ b/os/x11/x11.cpp
@@ -73,4 +73,15 @@ XInput* X11::xinput()
   return m_xinput.get();
 }
 
+MonitorsX11* X11::monitors()
+{
+  if (!m_monitors) {
+    // TODO: Use `XRRScreenChangeNotifyEvent` in the man page of Xrandr(3) to update this variable?
+    m_monitors = std::make_unique<MonitorsX11>();
+  }
+
+  return m_monitors.get();
+}
+
+
 } // namespace os

--- a/os/x11/x11.h
+++ b/os/x11/x11.h
@@ -10,7 +10,8 @@
 #pragma once
 
 #include "base/debug.h"
-#include "gfx/color_space.h"    // Include here avoid error with None
+#include "gfx/color_space.h"  // Include here avoid error with None
+#include "monitor.h"
 #include "os/event_queue.h"
 
 #include <X11/Xlib.h>
@@ -32,11 +33,13 @@ public:
   ::Display* display() const { return m_display; }
   ::XIM xim() const { return m_xim; }
   XInput* xinput();
+  MonitorsX11* monitors();
 
 private:
   ::Display* m_display;
   ::XIM m_xim;
   std::unique_ptr<XInput> m_xinput;
+  std::unique_ptr<MonitorsX11> m_monitors;
 };
 
 } // namespace os


### PR DESCRIPTION
Partially fix [aseprite issue 3118](https://github.com/aseprite/aseprite/issues/3118). 
X11 was never made with multi-monitor support in mind and, as a result, finding the workarea on multi-monitor setups is impossible without awful hacks. Instead, use the Xrandr X11 extension to query monitors, and their properties, to replace X11's display property in the operating-system level "Screen" implementation. 

With this patch, screen bounds will be correct on multi-monitor setups in X11 however the illusive workarea property will mirror the bounds.

I agree that my contributions are licensed under the MIT License.
