### PR TITLE
Improve skia text shaping & bounds calculation

### DIFF
--- a/text/skia_font.cpp
+++ b/text/skia_font.cpp
@@ -71,11 +71,13 @@ int SkiaFont::height() const
 
 int SkiaFont::textLength(const std::string& str) const
 {
-  return m_skFont.measureText(
-    str.c_str(),
-    str.size(),
-    SkTextEncoding::kUTF8,
-    nullptr);
+  return std::ceil(
+    m_skFont.measureText(
+      str.c_str(),
+      str.size(),
+      SkTextEncoding::kUTF8,
+      nullptr)
+  );
 }
 
 float SkiaFont::measureText(const std::string& str,

--- a/text/skia_font.cpp
+++ b/text/skia_font.cpp
@@ -124,9 +124,8 @@ glyph_t SkiaFont::codePointToGlyph(codepoint_t codepoint) const
 
 gfx::RectF SkiaFont::getGlyphBounds(glyph_t glyph) const
 {
-  float widths;
   SkRect bounds;
-  m_skFont.getWidthsBounds(&glyph, 1, &widths, &bounds, nullptr);
+  m_skFont.getWidthsBounds(&glyph, 1, nullptr, &bounds, nullptr);
   return os::from_skia(bounds);
 }
 

--- a/text/text_blob.cpp
+++ b/text/text_blob.cpp
@@ -69,10 +69,12 @@ gfx::RectF TextBlob::RunInfo::getGlyphBounds(const size_t i) const
   if (bounds.isEmpty()) {
     FontMetrics metrics;
     font->metrics(&metrics);
-    bounds.w = metrics.avgCharWidth;
-    bounds.h = -metrics.capHeight;
+    // avgCharWidth can be 0, so we grab the next most useful thing, the height
+    bounds.w = metrics.avgCharWidth > 0 ? metrics.avgCharWidth : metrics.xHeight;
+    bounds.h = 1.0;
   }
 
+  ASSERT(!bounds.isEmpty());
   bounds.offset(positions[i].x,
                 positions[i].y);
   if (offsets) {

--- a/text/text_blob.cpp
+++ b/text/text_blob.cpp
@@ -11,6 +11,7 @@
 #include "text/text_blob.h"
 
 #include "gfx/rect.h"
+#include "gfx/size.h"
 #include "text/font.h"
 #include "text/font_metrics.h"
 #include "text/sprite_text_blob.h"
@@ -65,21 +66,17 @@ gfx::RectF TextBlob::RunInfo::getGlyphBounds(const size_t i) const
 
   gfx::RectF bounds = font->getGlyphBounds(glyphs[i]);
 
-  // Get bounds of whitespace
+  // Get bounds of whitespace from a space glyph.
   if (bounds.isEmpty()) {
-    FontMetrics metrics;
-    font->metrics(&metrics);
-    // avgCharWidth can be 0, so we grab the next most useful thing, the height
-    bounds.w = metrics.avgCharWidth > 0 ? metrics.avgCharWidth : metrics.xHeight;
-    bounds.h = 1.0;
+    auto glyph = font->getGlyphBounds(' ');
+    bounds.w = glyph.w - glyph.x;
+    bounds.h = glyph.h - glyph.y;
   }
 
   ASSERT(!bounds.isEmpty());
-  bounds.offset(positions[i].x,
-                positions[i].y);
+  bounds.offset(positions[i]);
   if (offsets) {
-    bounds.offset(offsets[i].x,
-                  offsets[i].y);
+    bounds.offset(offsets[i]);
   }
 
   // Add global "point" offset to the bounds.

--- a/text/text_blob.h
+++ b/text/text_blob.h
@@ -59,12 +59,12 @@ namespace text {
 
     class RunHandler {
     public:
-      virtual ~RunHandler() { }
+      virtual ~RunHandler() = default;
       virtual void commitRunBuffer(RunInfo& info) = 0;
     };
 
-    TextBlob(const gfx::RectF& bounds) : m_bounds(bounds) { }
-    virtual ~TextBlob() { }
+    explicit TextBlob(const gfx::RectF& bounds) : m_bounds(bounds) {}
+    virtual ~TextBlob() = default;
 
     // Returns exact bounds that are required to draw this TextBlob.
     gfx::RectF bounds();


### PR DESCRIPTION
Fixes Skia crashes on Windows by using different bounds calculations and a more complete shape() function call.
