### PR TITLE
Fix as_nsdragoperation

### DIFF
--- a/os/osx/dnd.mm
+++ b/os/osx/dnd.mm
@@ -72,7 +72,7 @@ bool DragDataProviderOSX::contains(DragDataItemType type)
 
 NSDragOperation as_nsdragoperation(const os::DropOperation op)
 {
-  NSDragOperation nsdop;
+  NSDragOperation nsdop = NSDragOperationNone;
   if (static_cast<int>(op) & static_cast<int>(os::DropOperation::Copy))
     nsdop |= NSDragOperationCopy;
 
@@ -87,7 +87,7 @@ NSDragOperation as_nsdragoperation(const os::DropOperation op)
 
 os::DropOperation as_dropoperation(const NSDragOperation nsdop)
 {
-  int op = 0;
+  int op = static_cast<int>(os::DropOperation::None);
   if (nsdop & NSDragOperationCopy)
     op |= static_cast<int>(os::DropOperation::Copy);
 

--- a/os/win/dnd.cpp
+++ b/os/win/dnd.cpp
@@ -33,7 +33,7 @@ DWORD as_dropeffect(const os::DropOperation op)
 
 os::DropOperation as_dropoperation(DWORD pdwEffect)
 {
-  int op = 0;
+  int op = static_cast<int>(os::DropOperation::None);
   if (pdwEffect & DROPEFFECT_COPY)
     op |= static_cast<int>(os::DropOperation::Copy);
 


### PR DESCRIPTION
The variable used as the return value of the function had an undefined initial value which lead to unpredictable return values. 
Also took the chance to refactor a couple of lines of code.
