### PR TITLE
Add list_files filtering

### DIFF
--- a/base/fs.h
+++ b/base/fs.h
@@ -65,7 +65,20 @@ namespace base {
   // elements (is a normalized path).
   std::string get_absolute_path(const std::string& path);
 
-  paths list_files(const std::string& path);
+  // Item types that list_files() can be filtered by
+  enum class ItemType {
+      All,
+      Directories,
+      Files
+  };
+
+  // List all the items in a given path by default, two other parameters second parameters:
+  // filter can be use to distinguish between All items, directories and files.
+  // The name search can be used to match files by extension with something like "*.png" or by exact
+  // match without wildcards.
+  paths list_files(const std::string& path,
+                         ItemType filter = ItemType::All,
+                         const std::string& = "*");
 
   // Returns true if the given character is a valud path separator
   // (any of '\' or '/' characters).

--- a/base/fs.h
+++ b/base/fs.h
@@ -77,8 +77,8 @@ namespace base {
   // The name search can be used to match files by extension with something like "*.png" or by exact
   // match without wildcards.
   paths list_files(const std::string& path,
-                         ItemType filter = ItemType::All,
-                         const std::string& = "*");
+                   ItemType filter = ItemType::All,
+                   const std::string& = "*");
 
   // Returns true if the given character is a valud path separator
   // (any of '\' or '/' characters).

--- a/base/fs_win32.h
+++ b/base/fs_win32.h
@@ -181,8 +181,8 @@ std::string get_absolute_path(const std::string& path)
 }
 
 paths list_files(const std::string& path,
-                       ItemType filter,
-                       const std::string& match)
+                 ItemType filter,
+                 const std::string& match)
 {
   WIN32_FIND_DATA fd;
   paths files;
@@ -191,7 +191,7 @@ paths list_files(const std::string& path,
     FindExInfoBasic,
     &fd,
     (filter == ItemType::Directories) ? FindExSearchLimitToDirectories :
-                                             FindExSearchNameMatch,
+                                        FindExSearchNameMatch,
     NULL,
     0);
 

--- a/base/fs_win32.h
+++ b/base/fs_win32.h
@@ -180,19 +180,40 @@ std::string get_absolute_path(const std::string& path)
   return to_utf8(buffer);
 }
 
-paths list_files(const std::string& path)
+paths list_files(const std::string& path,
+                       ItemType filter,
+                       const std::string& match)
 {
   WIN32_FIND_DATA fd;
   paths files;
-  HANDLE handle = FindFirstFile(base::from_utf8(base::join_path(path, "*")).c_str(), &fd);
-  if (handle) {
-    do {
-      std::string filename = base::to_utf8(fd.cFileName);
-      if (filename != "." && filename != "..")
-        files.push_back(filename);
-    } while (FindNextFile(handle, &fd));
-    FindClose(handle);
-  }
+  HANDLE handle = FindFirstFileEx(
+    base::from_utf8(base::join_path(path, match)).c_str(),
+    FindExInfoBasic,
+    &fd,
+    (filter == ItemType::Directories) ? FindExSearchLimitToDirectories :
+                                             FindExSearchNameMatch,
+    NULL,
+    0);
+
+  if (handle == INVALID_HANDLE_VALUE)
+    return files;
+
+  do {
+    if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+      if (filter == ItemType::Files)
+        continue;
+
+      if (lstrcmpW(fd.cFileName, L".") == 0 ||
+          lstrcmpW(fd.cFileName, L"..") == 0)
+        continue;
+    }
+    else if (filter == ItemType::Directories)
+      continue;
+
+    files.push_back(base::to_utf8(fd.cFileName));
+  } while (FindNextFile(handle, &fd));
+
+  FindClose(handle);
   return files;
 }
 


### PR DESCRIPTION
As part of my work on [#4610](https://github.com/aseprite/aseprite/issues/4610) I've added directory/file filtering and pattern matching to `base::list_files` and made some optimizations and other changes:

 * Now avoids allocations as much as possible
 * Uses `FindFirstFileEx` on Windows which has flags to get directories directly and returns a more basic structure.
 * Uses `fnmatch` on Unix to replicate the wildcard matching Windows behavior

This allows us to use list_files much more efficiently, since before you had to do:

```cpp
for (auto& item : base::list_files(path)) {
  if (base::is_file(base::join_path(path, item)) && base::get_file_extension(item) == "png")
	do_something(item);
 }
```
which caused file attributes to be fetched twice, once when listing and another time when calling `is_file`, resulting in double the amount of IO operations. Now we can now just do:

```cpp
for (auto& item : base::list_files(path, ItemType::Files, "*.png")) {
	do_something(item);
 }
```

which is faster, and IMO more ergonomic.

I'll be working on a PR to modify aseprite to take advantage of this next, figured we can be getting the benefits of what I'm doing for the "recent files" fix and it'll make that easier to review.

There's a couple of things for which I'd like your opinion @dacap:
 * "list_files" as a name is _technically_ correct on Linux since "everything is a file" but in practical terms the function is a misnomer, do we wanna change that? Leaving it is fine it's just a pet peeve of mine.
 * Speaking of names, I struggled naming the filtering enum, I don't like the word "type" in there, taking suggestions.
 * This does not break source compatibility but definitely breaks binary compatibility, is that something we care about at this point in time?