### PR TITLE
Disable periodic dragging updates

### DIFF
--- a/os/osx/view.h
+++ b/os/osx/view.h
@@ -65,6 +65,7 @@ namespace os {
 - (void)createMouseTrackingArea;
 - (void)destroyMouseTrackingArea;
 - (void)updateCurrentCursor;
+- (BOOL)wantsPeriodicDraggingUpdates;
 - (NSDragOperation)draggingEntered:(id<NSDraggingInfo>)sender;
 - (NSDragOperation)draggingUpdated:(id<NSDraggingInfo>)sender;
 - (void)draggingExited:(id<NSDraggingInfo>)sender;

--- a/os/osx/view.mm
+++ b/os/osx/view.mm
@@ -668,6 +668,11 @@ os::DragEvent newDragEvent(id<NSDraggingInfo> sender)
                        ddProvider);
 }
 
+- (BOOL)wantsPeriodicDraggingUpdates
+{
+  return false;
+}
+
 - (NSDragOperation)draggingEntered:(id<NSDraggingInfo>)sender
 {
   WindowOSXObjc* target = (WindowOSXObjc*)sender.draggingDestinationWindow;


### PR DESCRIPTION
On macOS receive dragging events only when mouse is moved while dragging is in progress, and not periodically.
