### PR TITLE
Add possibility to set a webp decoding function

### DIFF
--- a/os/dnd.cpp
+++ b/os/dnd.cpp
@@ -19,6 +19,7 @@ static DecoderFunc g_decode_png = default_decode_png;
 static DecoderFunc g_decode_jpg = default_decode_jpg;
 static DecoderFunc g_decode_bmp = default_decode_bmp;
 static DecoderFunc g_decode_gif = default_decode_gif;
+static DecoderFunc g_decode_webp = nullptr;
 
 void set_decode_png(DecoderFunc func)
 {
@@ -40,6 +41,11 @@ void set_decode_gif(DecoderFunc func)
   g_decode_gif = func;
 }
 
+void set_decode_webp(DecoderFunc func)
+{
+  g_decode_webp = func;
+}
+
 SurfaceRef decode_png(const uint8_t* buf, const uint32_t len)
 {
   return g_decode_png(buf, len);
@@ -58,6 +64,11 @@ SurfaceRef decode_bmp(const uint8_t* buf, const uint32_t len)
 SurfaceRef decode_gif(const uint8_t* buf, const uint32_t len)
 {
   return g_decode_gif(buf, len);
+}
+
+SurfaceRef decode_webp(const uint8_t* buf, const uint32_t len)
+{
+  return g_decode_webp ? g_decode_webp(buf, len) : nullptr;
 }
 
 } // namespace os

--- a/os/dnd.h
+++ b/os/dnd.h
@@ -36,11 +36,13 @@ namespace os {
   void set_decode_jpg(DecoderFunc func);
   void set_decode_bmp(DecoderFunc func);
   void set_decode_gif(DecoderFunc func);
+  void set_decode_webp(DecoderFunc func);
 
   SurfaceRef decode_png(const uint8_t* buf, uint32_t len);
   SurfaceRef decode_jpg(const uint8_t* buf, uint32_t len);
   SurfaceRef decode_bmp(const uint8_t* buf, uint32_t len);
   SurfaceRef decode_gif(const uint8_t* buf, uint32_t len);
+  SurfaceRef decode_webp(const uint8_t* buf, uint32_t len);
 #endif
   // Operations that can be supported by source and target windows in a drag
   // and drop operation.

--- a/os/win/dnd.cpp
+++ b/os/win/dnd.cpp
@@ -240,6 +240,9 @@ SurfaceRef DragDataProviderWin::getImage()
 
         if (ext == "BMP")
           return os::decode_bmp(content, content.size());
+
+        if (ext == "WEBP")
+          return os::decode_webp(content, content.size());
       }
     }
   }
@@ -303,7 +306,8 @@ bool DragDataProviderWin::contains(DragDataItemType type)
                 std::string ext = base::get_file_extension(filename);
                 std::transform(ext.begin(), ext.end(), ext.begin(), ::toupper);
                 if (ext == "PNG" || ext == "JPG" || ext == "JPEG" ||
-                    ext == "JPE" || ext == "GIF" || ext == "BMP")
+                    ext == "JPE" || ext == "GIF" || ext == "BMP" ||
+                    ext == "WEBP")
                   return true;
               }
             }


### PR DESCRIPTION
This is useful in Windows to let the application set this function to decode webp data present when some applications provide it when dropping some element (like Chrome does when dragging&dropping an image from a result page).
