### PR TITLE
Removes extra qualification in function signature

### DIFF
--- a/os/win/dnd.h
+++ b/os/win/dnd.h
@@ -56,7 +56,7 @@ namespace os {
                                    DWORD* pdwEffect) override;
 
   private:
-    DragEvent DragTargetAdapter::newDragEvent(POINTL* pt, DWORD* pdwEffect);
+    DragEvent newDragEvent(POINTL* pt, DWORD* pdwEffect);
 
     ULONG m_ref = 0;
     Window* m_window = nullptr;


### PR DESCRIPTION

    This fixes the following compiler error with gcc.
    
    laf/os/win/dnd.h:59:15: error: extra qualification
    'os::DragTargetAdapter::' on member 'newDragEven' [-fpermissive]
    59 | DragEvent DragTargetAdapter::newDragEvent(POINTL* pt, DWORD* pdwEffect);
       |           ^~~~~~~~~~~~~~~~~
