### PR TITLE
Add a string_view variant of base::split_string()

### DIFF
--- a/base/split_string.cpp
+++ b/base/split_string.cpp
@@ -13,12 +13,10 @@
 #include <algorithm>
 
 namespace {
-
   struct is_separator {
     const std::string* separators;
 
-    is_separator(const std::string* seps) : separators(seps) {
-    }
+    is_separator(const std::string* seps) : separators(seps) {}
 
     bool operator()(std::string::value_type chr) const
     {
@@ -32,6 +30,22 @@ namespace {
     }
   };
 
+  struct is_separator_view {
+    const std::string_view* separators;
+
+    is_separator_view(const std::string_view* seps) : separators(seps) {}
+
+    bool operator()(std::string_view::value_type chr) const
+    {
+      for (std::string_view::const_iterator
+        it = separators->begin(),
+        end = separators->end(); it != end; ++it) {
+        if (chr == *it)
+          return true;
+      }
+      return false;
+    }
+  };
 }
 
 void base::split_string(const std::string& string,
@@ -49,6 +63,29 @@ void base::split_string(const std::string& string,
     if (end != std::string::npos) {
       parts.push_back(string.substr(beg, end - beg));
       beg = end+1;
+    }
+    else {
+      parts.push_back(string.substr(beg));
+      break;
+    }
+  }
+}
+
+void base::split_string(const std::string_view& string,
+                        std::vector<std::string_view>& parts,
+                        const std::string_view& separators)
+{
+  const std::size_t elements =
+    1 + std::count_if(string.begin(), string.end(),
+      is_separator_view(&separators));
+  parts.reserve(elements);
+
+  std::size_t beg = 0, end;
+  while (true) {
+    end = string.find_first_of(separators, beg);
+    if (end != std::string::npos) {
+      parts.push_back(string.substr(beg, end - beg));
+      beg = end + 1;
     }
     else {
       parts.push_back(string.substr(beg));

--- a/base/split_string.h
+++ b/base/split_string.h
@@ -9,14 +9,17 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace base {
-
   void split_string(const std::string& string,
                     std::vector<std::string>& parts,
                     const std::string& separators);
 
+  void split_string(const std::string_view& string,
+                    std::vector<std::string_view>& parts,
+                    const std::string_view& separators);
 }
 
 #endif

--- a/base/split_string_tests.cpp
+++ b/base/split_string_tests.cpp
@@ -38,7 +38,47 @@ TEST(SplitString, OneSeparator)
 
 TEST(SplitString, MultipleSeparators)
 {
+  std::string string = "Hello,World";
   std::vector<std::string> result;
+  base::split_string(string, result, ",r");
+  ASSERT_EQ(3, result.size());
+  EXPECT_EQ("Hello", result[0]);
+  EXPECT_EQ("Wo", result[1]);
+  EXPECT_EQ("ld", result[2]);
+}
+
+TEST(SplitStringView, Empty)
+{
+  const std::string_view string = "";
+  std::vector<std::string_view> result;
+  base::split_string("", result, ",");
+  ASSERT_EQ(1, result.size());
+  EXPECT_EQ("", result[0]);
+}
+
+TEST(SplitStringView, NoSeparator)
+{
+  const std::string_view string = "Hello,World";
+  std::vector<std::string_view> result;
+  base::split_string(string, result, "");
+  ASSERT_EQ(1, result.size());
+  EXPECT_EQ("Hello,World", result[0]);
+}
+
+TEST(SplitStringView, OneSeparator)
+{
+  const std::string_view string = "Hello,World";
+  std::vector<std::string_view> result;
+  base::split_string("Hello,World", result, ",");
+  ASSERT_EQ(2, result.size());
+  EXPECT_EQ("Hello", result[0]);
+  EXPECT_EQ("World", result[1]);
+}
+
+TEST(SplitStringView, MultipleSeparators)
+{
+  const std::string_view string = "Hello,World";
+  std::vector<std::string_view> result;
   base::split_string("Hello,World", result, ",r");
   ASSERT_EQ(3, result.size());
   EXPECT_EQ("Hello", result[0]);


### PR DESCRIPTION
Adds a string_view version of `base::split_string`

Benchmarked difference between the two versions of the function puts the string_view version at around 36-37% faster, although it wasn't extensive testing, just a little microbenchmark:

```cpp
  auto t0 = std::chrono::high_resolution_clock::now();
  {
    const std::string_view string = "Hello,World";
    for (int i = 0; i < 200000; i++) {
      std::vector<std::string_view> result;
      base::split_string("Hello,World", result, ",");
    }
  }

  auto t1 = std::chrono::high_resolution_clock::now();
  auto view = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
  t0 = std::chrono::high_resolution_clock::now();

  {
    const std::string string2 = "Hello,World";
    for (int i = 0; i < 200000; i++) {
      std::vector<std::string> result;
      base::split_string(string2, result, ",");
    }
  }

  t1 = std::chrono::high_resolution_clock::now();
  auto noView = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();

  std::cout << "string_view: " << view << " us" << std::endl;
  std::cout << "string:      " << noView << " us" << std::endl;
```