### PR TITLE
[X11] Fix drag & drop may stop receiving files in xwayland

### DIFF
--- a/os/x11/window.cpp
+++ b/os/x11/window.cpp
@@ -1317,7 +1317,6 @@ void WindowX11::processX11Event(XEvent& event)
           XFree(prop);
         }
 
-        const ::Window root = XDefaultRootWindow(m_display);
         XEvent event2;
         memset(&event2, 0, sizeof(event2));
         event2.xany.type = ClientMessage;
@@ -1329,7 +1328,7 @@ void WindowX11::processX11Event(XEvent& event)
         event2.xclient.data.l[1] = (successful ? 1 : 0);
         event2.xclient.data.l[2] = 0;
         event2.xclient.data.l[3] = 0;
-        XSendEvent(m_display, root, 0, 0, &event2);
+        XSendEvent(m_display, g_dndSource, 0, 0, &event2);
       }
       break;
 


### PR DESCRIPTION
Fix 2 drag & drop issues observed on KDE Wayland, using XWayland.

Changed `XdndFinished` event to be sent to the source window.
If send it to the root window, after dropping the first file, subsequent files can't be dropped.

Added handling `XdndEnter` event to check data type.
If the dragged item isn't a file, then reject dropping. This gives visual cursor feedback and prevents the drop event.
Possible fix for: When an unsupported data type is dropped to the window, subsequent files can't be dropped.

Feel free to pick only the first commit. The first issue is more problematic, and the fix doesn't require too many changes.

I agree that my contributions are licensed under the MIT License.