### PR TITLE
Move font_paths files from aseprite to laf

### DIFF
--- a/os/CMakeLists.txt
+++ b/os/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LAF_OS_SOURCES
   common/main.cpp
   common/system.cpp
   dnd.cpp
+  font_path.cpp
   system.cpp
   window.cpp)
 if(WIN32)
@@ -17,6 +18,7 @@ if(WIN32)
     win/color_space.cpp
     win/dnd.cpp
     win/event_queue.cpp
+    win/font_path_win.cpp
     win/keys.cpp
     win/native_dialogs.cpp
     win/system.cpp
@@ -34,6 +36,7 @@ elseif(APPLE)
       osx/dnd.mm
       osx/color_space.mm
       osx/event_queue.mm
+      osx/font_path_osx.mm
       osx/keys.mm
       osx/logger.mm
       osx/menus.mm
@@ -46,6 +49,7 @@ elseif(APPLE)
 else()
   list(APPEND LAF_OS_SOURCES
     x11/event_queue.cpp
+    x11/font_path_unix.cpp
     x11/keys.cpp
     x11/native_dialogs.cpp
     x11/system.cpp

--- a/os/font_path.cpp
+++ b/os/font_path.cpp
@@ -1,0 +1,35 @@
+// LAF OS Library
+// Copyright (C) 2024  Igara Studio S.A.
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
+#include "os/font_path.h"
+
+#include "base/fs.h"
+
+namespace os {
+
+std::string find_font(const std::string& firstDir, const std::string& filename)
+{
+  std::string fn = base::join_path(firstDir, filename);
+  if (base::is_file(fn))
+    return fn;
+
+  base::paths fontDirs;
+  get_font_dirs(fontDirs);
+
+  for (const std::string& dir : fontDirs) {
+    fn = base::join_path(dir, filename);
+    if (base::is_file(fn))
+      return fn;
+  }
+
+  return std::string();
+}
+
+} // namespace os

--- a/os/font_path.h
+++ b/os/font_path.h
@@ -1,0 +1,22 @@
+// LAF OS Library
+// Copyright (C) 2024  Igara Studio S.A.
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifndef OS_FONT_PATH_H_INCLUDED
+#define OS_FONT_PATH_H_INCLUDED
+#pragma once
+
+#include "base/paths.h"
+
+#include <string>
+
+namespace os {
+
+void get_font_dirs(base::paths& fontDirs);
+std::string find_font(const std::string& firstDir, const std::string& filename);
+
+} // namespace os
+
+#endif

--- a/os/osx/font_path_osx.mm
+++ b/os/osx/font_path_osx.mm
@@ -1,0 +1,30 @@
+// LAF OS Library
+// Copyright (C) 2024  Igara Studio S.A.
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
+#include "os/font_path.h"
+
+#include "base/fs.h"
+
+#include <cstdlib>
+
+namespace os {
+
+// TODO use a Cocoa API to get the list of paths
+void get_font_dirs(base::paths& fontDirs)
+{
+  const char* home = std::getenv("HOME");
+  if (home) {
+    fontDirs.push_back(base::join_path(home, "Library/Fonts"));
+  }
+  fontDirs.push_back("/Library/Fonts");
+  fontDirs.push_back("/System/Library/Fonts/");
+}
+
+} // namespace os

--- a/os/win/font_path_win.cpp
+++ b/os/win/font_path_win.cpp
@@ -1,0 +1,42 @@
+// LAF OS Library
+// Copyright (C) 2024  Igara Studio S.A.
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
+#include "os/font_path.h"
+
+#include "base/fs.h"
+#include "base/string.h"
+
+#include <cctype>
+#include <shlobj.h>
+#include <windows.h>
+
+namespace app {
+
+void get_font_dirs(base::paths& fontDirs)
+{
+  std::vector<wchar_t> buf(MAX_PATH + 1);
+
+  // Fonts in system fonts directory
+  HRESULT hr = SHGetFolderPath(nullptr, CSIDL_FONTS, nullptr, SHGFP_TYPE_DEFAULT, &buf[0]);
+  if (hr == S_OK)
+    fontDirs.push_back(base::to_utf8(&buf[0]));
+
+  // Fonts in ...\AppData\Local\Microsoft\Windows\Fonts
+  hr = SHGetFolderPath(nullptr, CSIDL_LOCAL_APPDATA, nullptr, SHGFP_TYPE_CURRENT, &buf[0]);
+  if (hr == S_OK) {
+    std::string userPath = base::to_utf8(&buf[0]);
+    userPath = base::join_path(userPath, "Microsoft\\Windows\\Fonts");
+    if (base::is_directory(userPath) && (fontDirs.empty() || userPath != fontDirs.back())) {
+      fontDirs.push_back(userPath);
+    }
+  }
+}
+
+} // namespace app

--- a/os/x11/font_path_unix.cpp
+++ b/os/x11/font_path_unix.cpp
@@ -1,0 +1,48 @@
+// LAF OS Library
+// Copyright (C) 2024  Igara Studio S.A.
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
+#include "os/font_path.h"
+
+#include "base/fs.h"
+
+#include <queue>
+
+namespace app {
+
+base::paths g_cache;
+
+void get_font_dirs(base::paths& fontDirs)
+{
+  if (!g_cache.empty()) {
+    fontDirs = g_cache;
+    return;
+  }
+
+  std::queue<std::string> q;
+  q.push("~/.fonts");
+  q.push("/usr/local/share/fonts");
+  q.push("/usr/share/fonts");
+
+  while (!q.empty()) {
+    std::string fontDir = q.front();
+    q.pop();
+
+    fontDirs.push_back(fontDir);
+
+    for (const auto& file : base::list_files(fontDir, base::ItemType::Directories)) {
+      std::string fullpath = base::join_path(fontDir, file);
+      q.push(fullpath); // Add subdirectory in the queue
+    }
+  }
+
+  g_cache = fontDirs;
+}
+
+} // namespace app


### PR DESCRIPTION
Moves the font_path* files from Aseprite source into LAF's "os" namespace. I did this work because when I was trying to find the cause of https://github.com/aseprite/aseprite/issues/4795 I wanted to create an isolated simple app showing just a window with a menu using the aseprite ui, without using any aseprite code. And these files were one of the reasons that made it impossible to do it, hence they had to be moved.

