### PR TITLE
[osx] Mimic Windows OS's floating windows behavior

### DIFF
--- a/os/osx/app_delegate.mm
+++ b/os/osx/app_delegate.mm
@@ -12,6 +12,7 @@
 #include <Cocoa/Cocoa.h>
 
 #include "os/osx/app_delegate.h"
+#include "os/osx/window.h"
 
 #include "base/fs.h"
 #include "os/event.h"
@@ -93,6 +94,13 @@
 
 - (void)applicationWillResignActive:(NSNotification*)notification
 {
+  for (id window : [NSApp windows]) {
+    if ([window isKindOfClass:[WindowOSXObjc class]] && [window isFloating]) {
+      [window setLevel:NSNormalWindowLevel];
+      [window orderWindow:NSWindowAbove relativeTo:0];
+    }
+  }
+
   NSEvent* event = [NSApp currentEvent];
   if (event != nil)
     [ViewOSX updateKeyFlags:event];
@@ -100,6 +108,12 @@
 
 - (void)applicationDidBecomeActive:(NSNotification*)notification
 {
+  for (id window : [NSApp windows]) {
+    if ([window isKindOfClass:[WindowOSXObjc class]] && [window isFloating]) {
+      [window setLevel:NSFloatingWindowLevel];
+    }
+  }
+
   NSEvent* event = [NSApp currentEvent];
   if (event != nil)
     [ViewOSX updateKeyFlags:event];

--- a/os/osx/window.h
+++ b/os/osx/window.h
@@ -41,6 +41,7 @@ class WindowOSX;
   WindowOSXDelegate* __strong m_delegate;
   ViewOSX* __strong m_view;
   int m_scale;
+  bool m_floating;
 }
 - (WindowOSXObjc*)initWithImpl:(os::WindowOSX*)impl spec:(const os::WindowSpec*)spec;
 - (os::WindowOSX*)impl;
@@ -51,6 +52,7 @@ class WindowOSX;
 - (void)setMousePosition:(const gfx::Point&)position;
 - (BOOL)setNativeCursor:(os::NativeCursor)cursor;
 - (BOOL)canBecomeKeyWindow;
+- (BOOL)isFloating;
 @end
 
 using WindowOSXObjc_id = WindowOSXObjc*;

--- a/os/osx/window.mm
+++ b/os/osx/window.mm
@@ -121,10 +121,9 @@
 
     [self makeKeyAndOrderFront:self];
 
-    if (spec->floating()) {
+    m_floating = spec->floating();
+    if (spec->floating())
       self.level = NSFloatingWindowLevel;
-      self.hidesOnDeactivate = true;
-    }
 
     if (spec->modal())
       self.level = NSModalPanelWindowLevel;
@@ -253,6 +252,11 @@
     return YES;
   else
     return NO;
+}
+
+- (BOOL)isFloating
+{
+  return m_floating;
 }
 
 - (void)noResponderFor:(SEL)eventSelector


### PR DESCRIPTION
This PR is based on the work of PR #113 and fixes the same issues: 
Fix aseprite/aseprite#4265
Fix aseprite/aseprite#4774

The difference between both PRs is on how they locate the floating windows to manipulate some of their properties.
