### PR TITLE
Suggest git submodule init / update in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ need for Pixman at all).
 
 ## Compile
 
+On a fresh clone of the repository, ensure git submodules are updated.
+
+```
+git submodule init
+git submodule update
+```
+
 To compile *laf* with Skia as backend you have to specify some
 variables pointing to a valid compiled version of Skia in your
 disk. In the following example `/skiadir` is the absolute path to a


### PR DESCRIPTION
When I went to build this (after building skia) I had these errors that blocked the build:

```
CMake Error at CMakeLists.txt:62 (add_subdirectory):
  The source directory

   path/to/laf/clip

  does not contain a CMakeLists.txt file.


CMake Error at third_party/CMakeLists.txt:10 (add_subdirectory):
  The source directory

   path/to/laf/third_party/googletest

  does not contain a CMakeLists.txt file.
```

The solution is to init and update submodules after cloning.

```
git submodule update --init
```

This will fetch the correct files and allow you to build.

It would be nice to make sure others know to init and update submodules when they fetch the code. I rarely work in projects that have submodules so I didn't immediately realize this was simple to solve.

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT
