### PR TITLE
Add missing <cstdint> header to use uint8_t

### DIFF
--- a/base/win/ver_query_values.cpp
+++ b/base/win/ver_query_values.cpp
@@ -12,6 +12,7 @@
 
 #include "base/string.h"
 
+#include <cstdint>
 #include <cstdio>
 #include <string_view>
 #include <vector>


### PR DESCRIPTION
This was needed to fix compilation against MinGW.

---

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the MIT License. -->
<!-- Please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT
