### PR TITLE
Handle screen DPI changes on Windows

### DIFF
--- a/os/win/winapi.cpp
+++ b/os/win/winapi.cpp
@@ -25,6 +25,12 @@ WinAPI::WinAPI()
     GET_PROC(m_user32, GetPointerInfo);
     GET_PROC(m_user32, GetPointerPenInfo);
     GET_PROC(m_user32, SetProcessDpiAwarenessContext);
+    GET_PROC(m_user32, GetWindowDpiAwarenessContext);
+    GET_PROC(m_user32, AreDpiAwarenessContextsEqual);
+    GET_PROC(m_user32, EnableNonClientDpiScaling);
+    GET_PROC(m_user32, GetDpiForWindow);
+    GET_PROC(m_user32, GetSystemMetricsForDpi);
+    GET_PROC(m_user32, AdjustWindowRectExForDpi);
   }
   if (m_ninput) {
     GET_PROC(m_ninput, CreateInteractionContext);

--- a/os/win/winapi.h
+++ b/os/win/winapi.h
@@ -47,6 +47,12 @@ typedef HRESULT(WINAPI* ProcessPointerFramesInteractionContext_Func)(
   const POINTER_INFO* pointerInfo);
 
 typedef BOOL(WINAPI* SetProcessDpiAwarenessContext_Func)(DPI_AWARENESS_CONTEXT value);
+typedef DPI_AWARENESS_CONTEXT(WINAPI* GetWindowDpiAwarenessContext_Func)(HWND hwnd);
+typedef BOOL(WINAPI* AreDpiAwarenessContextsEqual_Func)(DPI_AWARENESS_CONTEXT dpiContextA, DPI_AWARENESS_CONTEXT dpiContextB);
+typedef BOOL(WINAPI* EnableNonClientDpiScaling_Func)(HWND hwnd);
+typedef UINT(WINAPI* GetDpiForWindow_Func)(HWND hwnd);
+typedef int(WINAPI* GetSystemMetricsForDpi_Func)(int nIndex, UINT dpi);
+typedef BOOL(WINAPI* AdjustWindowRectExForDpi_Func)(LPRECT lpRect, DWORD dwStyle, BOOL bMenu, DWORD dwExStyle, UINT dpi);
 
 class WinAPI {
 public:
@@ -71,6 +77,14 @@ public:
   SetPropertyInteractionContext_Func SetPropertyInteractionContext = nullptr;
   ProcessPointerFramesInteractionContext_Func ProcessPointerFramesInteractionContext = nullptr;
 
+  // Functions introduced on Windows 10 version 1607
+  GetWindowDpiAwarenessContext_Func GetWindowDpiAwarenessContext = nullptr;
+  AreDpiAwarenessContextsEqual_Func AreDpiAwarenessContextsEqual = nullptr;
+  EnableNonClientDpiScaling_Func EnableNonClientDpiScaling = nullptr;
+  GetDpiForWindow_Func GetDpiForWindow = nullptr;
+  GetSystemMetricsForDpi_Func GetSystemMetricsForDpi = nullptr;
+  AdjustWindowRectExForDpi_Func AdjustWindowRectExForDpi = nullptr;
+  
   // Functions introduced on Windows 10 version 1703
   SetProcessDpiAwarenessContext_Func SetProcessDpiAwarenessContext = nullptr;
 

--- a/os/win/window.cpp
+++ b/os/win/window.cpp
@@ -266,7 +266,7 @@ WindowWin::WindowWin(const WindowSpec& spec)
 
   if (winApi.GetWindowDpiAwarenessContext) {
     double scaleFactor = winApi.GetDpiForWindow(m_hwnd) / (double) USER_DEFAULT_SCREEN_DPI;
-    m_scale = std::max(1, (int)(m_baseScale * scaleFactor + 0.51));
+    m_scale = std::ceil(m_baseScale * scaleFactor);
   }
 
   // This flag is used to avoid calling T::resizeImpl() when we

--- a/os/win/window.cpp
+++ b/os/win/window.cpp
@@ -977,7 +977,7 @@ LRESULT WindowWin::wndProc(UINT msg, WPARAM wparam, LPARAM lparam)
 
     case WM_DPICHANGED: {
       double scaleFactor = HIWORD(wparam) / (double) USER_DEFAULT_SCREEN_DPI;
-      m_scale = std::max(1, (int)(m_baseScale * scaleFactor + 0.51));
+      m_scale = std::ceil(m_baseScale * scaleFactor);
 
       RECT* prcNewWindow = (RECT*)lparam;
       SetWindowPos(m_hwnd,

--- a/os/win/window.cpp
+++ b/os/win/window.cpp
@@ -370,7 +370,7 @@ void WindowWin::setScale(int scale)
   double scaleFactor = m_scale / (double) m_baseScale;
   m_baseScale = scale;
   // round to nearest integer, rounding 0.5 up
-  m_scale = std::max(1, (int)(scale * scaleFactor + 0.51));
+  m_scale = std::ceil(m_baseScale * scaleFactor);
 
   // Align window size to new scale
   {

--- a/os/win/window.h
+++ b/os/win/window.h
@@ -39,6 +39,7 @@ public:
   os::ScreenRef screen() const override;
   os::ColorSpaceRef colorSpace() const override;
   int scale() const override { return m_scale; }
+  int baseScale() const override { return m_baseScale; }
   void setScale(int scale) override;
   bool isVisible() const override;
   void setVisible(bool visible) override;
@@ -144,6 +145,7 @@ private:
   std::unique_ptr<DragTargetAdapter> m_dragTargetAdapter = nullptr;
 
   int m_scale;
+  int m_baseScale;
   bool m_isCreated;
   // Since Windows Vista, it looks like Microsoft decided to change
   // the meaning of the window position to the shadow position (when

--- a/os/window.h
+++ b/os/window.h
@@ -103,6 +103,10 @@ public:
   // The window size will be a multiple of the scale.
   virtual void setScale(int scale) = 0;
 
+  // Returns the current window scale for default DPI value.
+  // It is constant across different displays.
+  virtual int baseScale() const { return scale(); }
+
   // Returns true if the window is visible in the screen.
   virtual bool isVisible() const = 0;
 


### PR DESCRIPTION
Issue aseprite/aseprite#4606, also possibly avoids having aseprite/aseprite#2740, and I think fixes aseprite/aseprite#4495.

On several displays with diffferent scale dragging the window from one screen to another makes everything either tiny or huge, depending on the direction it's dragged. This can be an issue when the screen with higher resolution is smaller in size, like a laptop with external monitor, or a pc with a screen tablet.

I tested these changes on 100%/200% and 150%/300% screen combination, windowed/maximized window, menu and preview windows, moving window with mouse and shift+wid+arrow key, and changing screen scale in settings w/ app running. As far as I can see it behaves same as other applications (namely, notepad) now. Except, rounding of 150% scale and 1x scale setting to 1x resolution feelt a bit confusing (personally) so i rounded it up.

PR aseprite/aseprite#4934 is needed to handle these changes properly.

### Window decorations

- Laf's WinAPI constructor (laf/os/win/winapi.cpp) tries to set process' dpi awareness to PER_MONITOR_AWARE_V2, and then and to PER_MONITOR_AWARE if first one fails. In Aseprite however both actually fail with "access denied", because it can only be set once, and `src/main/settings.manifest` already set it to V1.
- In addition to enabling DPI awareness V1, window needs to call EnableNonClientDpiScaling() in create event to make titlebar resize.
- GetSystemMetric and AdjustWindowRectEx need to be replaced with dpi-aware variants when available.

Corresponding commit to Aseprite repo changes manifest file to enable V2 dpi awareness, although when it's not available V1 works identical to it. Also theorethically this can be applied without the next commit if it's too messy.

### Window content

I think it's important that window content is intact when changing screen. Think of moving a preview window - doing additional zoom/pan would be annoying. It means we need to:
- Scale window borders proportional to dpi change.
- Adjust display scale factor, not UI scale.
- Not clamp scale factor at 4x when drawing.

The easiest wai I think is to scale pixel coordinates in laf window as `scale = baseScale * displayDPI / defaultDPI`, where baseScale is now the scaling chosen by user in the settings. Scale is used for input and painting same as before, while baseScale replaces it in window settings and initial values. This however breaks backwards compatibility, and I can't think of a simple way to keep it (e.g. need to handle window sizing outside window class for that).

There's also a few ways to sprovie API for this - i picked one with fewer changes. And maybe Window::setScale should now be setBaseScale but I don't think i got naming right anyway.

Corresponding commit to Aseprite repo replaces some scale() calls with baseScale() when needed.

-----

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT
