### PR TITLE
Add null UUID definition to use for comparing

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -56,6 +56,7 @@ set(BASE_SOURCES
   thread.cpp
   thread_pool.cpp
   time.cpp
+  uuid.cpp
   version.cpp)
 
 if(WIN32)

--- a/base/uuid.cpp
+++ b/base/uuid.cpp
@@ -1,0 +1,13 @@
+// LAF Base Library
+// Copyright (c) 2025  Igara Studio S.A.
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#include "base/uuid.h"
+
+namespace base {
+
+const Uuid Uuid::Null;
+
+} // namespace base

--- a/base/uuid.h
+++ b/base/uuid.h
@@ -1,5 +1,5 @@
 // LAF Base Library
-// Copyright (c) 2023  Igara Studio S.A.
+// Copyright (c) 2023-2025  Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -25,6 +25,9 @@ namespace base {
 // A universally unique identifier.
 class Uuid {
 public:
+  // Null UUID
+  static const Uuid Null;
+
   enum { HashSize = 36 };
 
   static Uuid Generate();


### PR DESCRIPTION
This PR just defines a "null" UUID  constant by introducing a static const member to the Uuid class.
