### PR TITLE
Create a new laf-dlgs-proc executable to run the file dialog in a child process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # LAF
-# Copyright (C) 2019-2024  Igara Studio S.A.
+# Copyright (C) 2019-2025  Igara Studio S.A.
 # Copyright (C) 2016-2018  David Capello
 
 cmake_minimum_required(VERSION 3.16)
@@ -31,6 +31,10 @@ endif()
 option(LAF_WITH_EXAMPLES "Enable LAF examples" ON)
 option(LAF_WITH_TESTS "Enable LAF tests" ON)
 option(LAF_WITH_CLIP "Enable clip module (required for future drag-and-drop feature)" ON)
+if(WIN32)
+  option(LAF_WITH_DLGS_PROC "Enable laf-dlgs-process.exe for Windows to open the FileDialog through an external process" OFF)
+  set(LAF_DLGS_PROC_NAME "dlgs_process" CACHE STRING "Name of the process to show native dialogs")
+endif()
 set(LAF_BACKEND ${LAF_DEFAULT_BACKEND} CACHE STRING "Select laf backend")
 set_property(CACHE LAF_BACKEND PROPERTY STRINGS "none" "skia")
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2018-2024  Igara Studio S.A.
+Copyright (c) 2018-2025  Igara Studio S.A.
 Copyright (c) 2016-2018  David Capello
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/dlgs/CMakeLists.txt
+++ b/dlgs/CMakeLists.txt
@@ -1,13 +1,38 @@
 # laf-dlgs
-# Copyright (C) 2024  Igara Studio S.A.
+# Copyright (C) 2024-2025  Igara Studio S.A.
 
 add_library(laf-dlgs file_dialog.cpp)
 target_link_libraries(laf-dlgs laf-base)
 
 if(WIN32)
-  target_sources(laf-dlgs PRIVATE file_dialog_win.cpp)
+  target_sources(laf-dlgs PRIVATE win/file_dialog_win.cpp)
 elseif(APPLE)
   target_sources(laf-dlgs PRIVATE file_dialog_osx.mm)
 else()
   target_sources(laf-dlgs PRIVATE file_dialog_x11.cpp)
+endif()
+
+if(LAF_WITH_DLGS_PROC)
+  add_executable(laf-dlgs-proc win/dlgs_process.cpp)
+  target_link_libraries(laf-dlgs-proc laf-base laf-dlgs
+  #   # shlwapi
+  #   kernel32 user32 gdi32 comdlg32 ole32 winmm
+  #   shlwapi psapi wininet comctl32 dbghelp dwmapi
+  #   msimg32
+  )
+  # target_link_options(laf-dlgs-proc PUBLIC -SUBSYSTEM:CONSOLE -ENTRY:wmain)
+  # target_link_options(laf-dlgs-proc PUBLIC -ENTRY:wmain)
+  set_target_properties(laf-dlgs-proc PROPERTIES
+    OUTPUT_NAME ${LAF_DLGS_PROC_NAME})
+
+  target_compile_definitions(laf-dlgs PRIVATE
+    -DLAF_DLGS_PROC_NAME="${LAF_DLGS_PROC_NAME}")
+  target_sources(laf-dlgs PRIVATE win/file_dialog_win_safe.cpp)
+
+# if(LAF_WITH_DLGS_PROC)
+#   # When we use the laf-dlgs-proc, laf-os depends on it to show the
+#   # native file dialog.
+#   add_dependencies(laf-os laf-dlgs-proc)
+# endif()
+
 endif()

--- a/dlgs/file_dialog.h
+++ b/dlgs/file_dialog.h
@@ -20,6 +20,14 @@ namespace dlgs {
 class FileDialog;
 using FileDialogRef = base::Ref<FileDialog>;
 
+#if LAF_WINDOWS
+class FileDialogDelegate {
+public:
+  virtual ~FileDialogDelegate() {}
+  virtual void onFolderChange(const std::string& path) = 0;
+};
+#endif // LAF_WINDOWS
+
 class FileDialog : public base::RefCount {
 public:
   enum class Type {
@@ -36,7 +44,10 @@ public:
   };
 
   struct Spec {
-#if LAF_MACOS
+#if LAF_WINDOWS
+    // Listen events of the FileDialog.
+    FileDialogDelegate* delegate = nullptr;
+#elif LAF_MACOS
     // Indicates which is the "Edit" menu (NSMenuItem*) with
     // Undo/Redo/Cut/Copy/Paste/etc. commands. Used by the
     // FileDialogOSX impl to completely replace the "Edit" menu with a
@@ -58,6 +69,10 @@ public:
   static FileDialogRef make(const Spec& spec);
 #if LAF_WINDOWS
   static FileDialogRef makeWin(const Spec& spec);
+  static FileDialogRef makeWinUnsafe(const Spec& spec);
+  #ifdef LAF_DLGS_PROC_NAME
+  static FileDialogRef makeWinSafe(const Spec& spec);
+  #endif
 #elif LAF_MACOS
   static FileDialogRef makeOSX(const Spec& spec);
 #elif LAF_LINUX

--- a/dlgs/win/dlgs_process.cpp
+++ b/dlgs/win/dlgs_process.cpp
@@ -1,0 +1,105 @@
+// laf-dlgs
+// Copyright (C) 2024  Igara Studio S.A.
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+//
+// Based in the work done in https://github.com/dacap/safedlgs/
+// prototype.
+//
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
+#ifdef LAF_DLGS_PROC_NAME
+  #error LAF_DLGS_PROC_NAME must not be defined for laf-dlgs-proc
+#endif
+
+#include "base/program_options.h"
+#include "base/string.h"
+#include "base/win/coinit.h"
+#include "dlgs/file_dialog.h"
+
+#include <werapi.h>
+#include <windows.h>
+
+#include <cstdio>
+
+class Delegate : public dlgs::FileDialogDelegate {
+public:
+  void onFolderChange(const std::string& path) override
+  {
+    // Print folder name in stdout.
+    std::wprintf(L"%s\n", base::from_utf8(path).c_str());
+    std::fflush(stdout);
+  }
+};
+
+int wmain(int argc, wchar_t** wargv)
+{
+  base::ProgramOptions po;
+  auto& parent(po.add("parent").requiresValue("<parent>"));
+  auto& type(po.add("type").requiresValue("<open|save>"));
+  auto& title(po.add("title").requiresValue("<title>"));
+  auto& filename(po.add("filename").requiresValue("<filename>"));
+
+  // Convert args to utf8 to parse them.
+  {
+    std::vector<std::string> argv_str(argc);
+    for (int i = 0; i < argc; ++i)
+      argv_str[i] = base::to_utf8(wargv[i]);
+
+    std::vector<const char*> argv(argc);
+    for (int i = 0; i < argc; ++i)
+      argv[i] = argv_str[i].data();
+
+    po.parse(argc, argv.data());
+  }
+
+  // Initialize COM library.
+  base::CoInit com;
+
+  // Avoid showing the "dlgs_process.exe has stopped working" dialog
+  // when this crashes.
+  SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+  WerSetFlags(WER_FAULT_REPORTING_NO_UI);
+
+  Delegate delegate;
+  dlgs::FileDialog::Spec spec;
+  spec.delegate = &delegate;
+
+  dlgs::FileDialogRef dlg = dlgs::FileDialog::makeWinUnsafe(spec);
+
+  // TODO this doesn't work, it looks like we cannot use the parent
+  // process HWND handle as parent of a file dialog in this other
+  // process (?)
+  HWND parentHandle = nullptr;
+  {
+    const std::string parentString = po.value_of(parent);
+    if (!parentString.empty())
+      parentHandle = (HWND)std::strtoull(parentString.c_str(), nullptr, 0);
+  }
+
+  if (po.value_of(type) == "save")
+    dlg->setType(dlgs::FileDialog::Type::SaveFile);
+  else
+    dlg->setType(dlgs::FileDialog::Type::OpenFile);
+
+  if (po.enabled(title))
+    dlg->setTitle(po.value_of(title));
+
+  if (po.enabled(filename))
+    dlg->setFileName(po.value_of(filename));
+
+  dlgs::FileDialog::Result result = dlg->show(parentHandle);
+  if (result == dlgs::FileDialog::Result::Error)
+    return 1;
+  else if (result == dlgs::FileDialog::Result::Cancel)
+    return 0;
+
+  // Print file name
+  std::wprintf(L"%s\n", base::from_utf8(dlg->fileName()).c_str());
+  std::fflush(stdout);
+  return 0;
+}

--- a/dlgs/win/file_dialog_win_safe.cpp
+++ b/dlgs/win/file_dialog_win_safe.cpp
@@ -1,0 +1,185 @@
+// laf-dlgs
+// Copyright (C) 2025  Igara Studio S.A.
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
+#ifndef LAF_DLGS_PROC_NAME
+  #error LAF_DLGS_PROC_NAME must be defined
+#endif
+
+#include "dlgs/file_dialog.h"
+
+#include "base/fs.h"
+#include "base/string.h"
+
+#include <shobjidl.h>
+#include <windows.h>
+
+#include <string>
+#include <vector>
+
+namespace dlgs {
+
+// FileDialog impl for Windows calling the external laf-dlgs-proc
+// executable. If the file dialog process crashes we don't kill the
+// main executable.
+class FileDialogWinSafe : public FileDialog {
+  static constexpr const int kBufSize = 4096;
+
+public:
+  FileDialogWinSafe(const Spec& spec) : m_spec(spec) {}
+
+  std::string fileName() override { return m_filename; }
+
+  void getMultipleFileNames(base::paths& output) override { output = m_filenames; }
+
+  void setFileName(const std::string& filename) override
+  {
+    m_filename = filename;
+    m_lastPath = base::from_utf8(base::get_file_path(filename));
+  }
+
+  Result show(void* parent) override
+  {
+    Result result = Result::Error;
+
+    std::string cmdLine = base::join_path(base::get_file_path(base::get_app_path()),
+                                          base::replace_extension(LAF_DLGS_PROC_NAME, "exe"));
+
+    if (parent) {
+      char buf[256];
+      std::snprintf(buf, sizeof(buf), "0x%p", buf);
+      cmdLine += " -parent ";
+      cmdLine += buf;
+    }
+
+    if (!m_title.empty()) {
+      cmdLine += " -title \"";
+      cmdLine += m_title;
+      cmdLine += "\"";
+    }
+
+    // Execute the laf-dlgs-proc as many times as crashes we receive
+    // (in fact we use a "retry" count to stop at certain point).
+    for (int retry = 0; retry < 100; ++retry) {
+      // Create a pipe for the STDOUT of the child process, so we can
+      // receive its output
+      SECURITY_ATTRIBUTES sa = {};
+      sa.nLength = sizeof(sa);
+      sa.lpSecurityDescriptor = nullptr;
+      sa.bInheritHandle = TRUE;
+
+      m_childRead = nullptr;
+      HANDLE childWrite = nullptr;
+      if (!CreatePipe(&m_childRead, &childWrite, &sa, 0))
+        break;
+
+      STARTUPINFOW si = {};
+      PROCESS_INFORMATION pi = {};
+      si.cb = sizeof(si);
+      si.hStdError = childWrite;
+      si.hStdOutput = childWrite;
+      si.hStdInput = INVALID_HANDLE_VALUE;
+      si.dwFlags = STARTF_USESTDHANDLES;
+      if (!CreateProcessW(nullptr,
+                          (LPWSTR)base::from_utf8(cmdLine).c_str(),
+                          nullptr,
+                          nullptr,
+                          TRUE,                                // bInheritHandles
+                          CREATE_NO_WINDOW | DETACHED_PROCESS, // dwCreationFlags
+                          nullptr,
+                          nullptr,
+                          &si,
+                          &pi)) {
+        break;
+      }
+
+      // Close handles that will not be used in this parent process
+      CloseHandle(pi.hThread);
+      CloseHandle(childWrite);
+
+      HANDLE readThread =
+        CreateThread(nullptr, 0, &FileDialogWinSafe::readChildDataThread, (LPVOID)this, 0, nullptr);
+
+      // Wait the laf-dlgs-proc to finish (or crash)
+      DWORD waitResult = WaitForSingleObject(pi.hProcess, INFINITE);
+
+      // Did the process crash?
+      DWORD exitCode = 0;
+      GetExitCodeProcess(pi.hProcess, &exitCode);
+      CloseHandle(pi.hProcess);
+      if (exitCode == 0xC0000005) {
+        // Run child process again
+        continue;
+      }
+
+      // Done (Cancel or OK)
+      if (exitCode == 1) {
+        result = FileDialog::Result::Cancel;
+      }
+      else {
+        result = FileDialog::Result::OK;
+        m_filename = base::to_utf8(m_lastPath);
+      }
+      break;
+    }
+
+    return result;
+  }
+
+  // This function is executed in a background thread to read the
+  // output from laf-dlgs-proc process.
+  int onReadChildDataThread()
+  {
+    WCHAR buf[kBufSize];
+    ZeroMemory(buf, sizeof(buf));
+
+    while (TRUE) {
+      buf[0] = 0;
+
+      DWORD read = 0;
+      BOOL result = ReadFile(m_childRead, buf, sizeof(buf), &read, nullptr);
+      if (!result || read == 0)
+        break;
+
+      read /= 2; // As "buf" is WCHAR
+
+      m_lastPath.clear();
+      for (int i = 0; i < read; ++i) {
+        if (buf[i] == '\r')
+          continue;
+        if (buf[i] == '\n') {
+          m_lastPath.clear();
+          continue;
+        }
+        m_lastPath.push_back(buf[i]);
+      }
+    }
+    return 0;
+  }
+
+  static DWORD WINAPI readChildDataThread(LPVOID data)
+  {
+    auto* self = (FileDialogWinSafe*)data;
+    return self->onReadChildDataThread();
+  }
+
+  Spec m_spec;
+  std::string m_filename;
+  base::paths m_filenames;
+  std::string m_initialDir;
+  HANDLE m_childRead = nullptr;
+  std::wstring m_lastPath;
+};
+
+FileDialogRef FileDialog::makeWinSafe(const Spec& spec)
+{
+  return base::make_ref<FileDialogWinSafe>(spec);
+}
+
+} // namespace dlgs


### PR DESCRIPTION
We want to fix https://github.com/aseprite/aseprite/issues/4412 in some way, this is not yet ready because it looks like a child process cannot use `IModalWindow::Show` with a parent process HWND handle.