### PR TITLE
Fix NSApplication initialization to prevent some issues on macOS

### DIFF
--- a/os/osx/app.mm
+++ b/os/osx/app.mm
@@ -52,7 +52,14 @@ public:
 
   void finishLaunching()
   {
-    [m_app finishLaunching];
+    // [m_app run] can only be called once.
+    if (![[NSRunningApplication currentApplication] isFinishedLaunching])
+      // Note that the [m_app run] call doesn't block because we are calling
+      // [NSApp stop] from [AppDelegateOSX applicationDidFinishLaunching]. We only
+      // need the application's initialization done inside run to prevent issues
+      // such as: https://github.com/aseprite/aseprite/issues/4795
+      [m_app run];
+
     [m_appDelegate resetCliFiles];
   }
 

--- a/os/osx/app.mm
+++ b/os/osx/app.mm
@@ -52,13 +52,24 @@ public:
 
   void finishLaunching()
   {
-    // [m_app run] can only be called once.
-    if (![[NSRunningApplication currentApplication] isFinishedLaunching])
-      // Note that the [m_app run] call doesn't block because we are calling
-      // [NSApp stop] from [AppDelegateOSX applicationDidFinishLaunching]. We only
-      // need the application's initialization done inside run to prevent issues
-      // such as: https://github.com/aseprite/aseprite/issues/4795
-      [m_app run];
+    id runningApp = [NSRunningApplication currentApplication];
+    // [m_app run] must be called once, if the app didn't finish launching yet.
+    if (![runningApp isFinishedLaunching]) {
+      // The run method must be called in GUI mode only, otherwise the
+      // [AppDelegateOSX applicationDidFinishLaunching] doesn't get called
+      // and [m_app run] ends up blocking the app.
+      if ([runningApp activationPolicy] == NSApplicationActivationPolicyRegular) {
+        // Note that the [m_app run] call doesn't block because we are calling
+        // [NSApp stop] from [AppDelegateOSX applicationDidFinishLaunching]. We only
+        // need the application's initialization done inside run to prevent issues
+        // such as: https://github.com/aseprite/aseprite/issues/4795
+        [m_app run];
+      }
+      else {
+        // The app is running in CLI mode, then we just call finishLaunching.
+        [m_app finishLaunching];
+      }
+    }
 
     [m_appDelegate resetCliFiles];
   }

--- a/os/osx/app_delegate.h
+++ b/os/osx/app_delegate.h
@@ -29,6 +29,7 @@
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication*)app;
 - (void)applicationWillTerminate:(NSNotification*)notification;
 - (void)applicationWillResignActive:(NSNotification*)notification;
+- (void)applicationDidFinishLaunching:(NSNotification*)notification;
 - (void)applicationDidBecomeActive:(NSNotification*)notification;
 - (void)applicationDidHide:(NSNotification*)notification;
 - (void)applicationDidUnhide:(NSNotification*)notification;

--- a/os/osx/app_delegate.mm
+++ b/os/osx/app_delegate.mm
@@ -106,6 +106,13 @@
     [ViewOSX updateKeyFlags:event];
 }
 
+- (void)applicationDidFinishLaunching:(NSNotification*)notification
+{
+  // We do not want that the [NSApplication run] call made from
+  // AppOSX::Impl::finishLaunching() blocks.
+  [NSApp stop:nil];
+}
+
 - (void)applicationDidBecomeActive:(NSNotification*)notification
 {
   for (id window : [NSApp windows]) {

--- a/os/system.h
+++ b/os/system.h
@@ -93,15 +93,16 @@ public:
   // files that were processed from the CLI arguments directly.
   virtual void markCliFileAsProcessed(const std::string& cliFile) = 0;
 
-  // On macOS it calls [NSApplication finishLaunching] that will
-  // produce some extra events like [NSApplicationDelegate
-  // application:openFiles:] which generates os::Event::DropFiles
-  // events for each file specified in the command line.
+  // On macOS it calls [NSApplication run], which in turn does two things:
+  // - It calls [NSApplication finishLaunching], which will produce some extra
+  // events like [NSApplicationDelegate application:openFiles:] which generates
+  // os::Event::DropFiles events for each file specified in the command line.
+  // - It initializes internal state of the NSApplication instance to make it
+  // behave as expected under some circumstances.
   //
-  // You can ignore those DropFiles events if you've already
-  // processed through the CLI arguments (app_main(argc, argv)) or
-  // you can use markCliFileAsProcessed() before calling this
-  // function.
+  // About the first point: you can ignore those DropFiles events if you've
+  // already processed through the CLI arguments (app_main(argc, argv)) or
+  // you can use markCliFileAsProcessed() before calling this function.
   virtual void finishLaunching() = 0;
 
   // We might need to call this function when the app is launched


### PR DESCRIPTION
By calling [NSApplication run] and then [NSApplication stop] we are able to initialize the application instance and prevent issues in fullscreen mode (fix aseprite/aseprite#4795)
