### PR TITLE
New base::task features

### DIFF
--- a/base/task.cpp
+++ b/base/task.cpp
@@ -58,6 +58,8 @@ void task::in_worker_thread()
   // This must be the latest statement in the worker thread (see
   // task::complete() comment)
   m_completed = true;
+  if (m_done)
+    m_done(m_token);
 }
 
 } // namespace base

--- a/base/task.cpp
+++ b/base/task.cpp
@@ -37,15 +37,15 @@ task_token& task::start(thread_pool& pool)
   return m_token;
 }
 
-bool task::try_skip(thread_pool& pool)
+bool task::try_pop(thread_pool& pool)
 {
-  bool skipped = pool.try_skip(m_token.m_work);
-  if (skipped) {
+  bool popped = pool.try_pop(m_token.m_work);
+  if (popped) {
     m_token.m_canceled = true;
     call_finished();
   }
 
-  return skipped;
+  return popped;
 }
 
 void task::call_finished()

--- a/base/task.cpp
+++ b/base/task.cpp
@@ -50,8 +50,14 @@ void task::in_worker_thread()
 
   m_state = state::FINISHED;
 
-  if (m_finished)
-    m_finished(m_token);
+  if (m_finished) {
+    try {
+      m_finished(m_token);
+    }
+    catch (const std::exception& ex) {
+      LOG(ERROR, "Exception executing 'finished' callback: %s\n", ex.what());
+    }
+  }
 }
 
 } // namespace base

--- a/base/task.cpp
+++ b/base/task.cpp
@@ -36,6 +36,7 @@ task_token& task::start(thread_pool& pool)
 
   // Reset flags for a running task
   m_running = true;
+  m_enqueued = true;
   m_completed = false;
   m_token.reset();
 
@@ -45,6 +46,7 @@ task_token& task::start(thread_pool& pool)
 
 void task::in_worker_thread()
 {
+  m_enqueued = false;
   try {
     if (!m_token.canceled())
       m_execute(m_token);

--- a/base/task.cpp
+++ b/base/task.cpp
@@ -60,8 +60,8 @@ void task::in_worker_thread()
   // This must be the latest statement in the worker thread (see
   // task::complete() comment)
   m_completed = true;
-  if (m_done)
-    m_done(m_token);
+  if (m_finished)
+    m_finished(m_token);
 }
 
 } // namespace base

--- a/base/task.cpp
+++ b/base/task.cpp
@@ -52,7 +52,8 @@ void task::call_finished()
 {
   if (m_finished) {
     try {
-      m_finished(m_token);
+      task_token token = m_token;
+      m_finished(token);
     }
     catch (const std::exception& ex) {
       LOG(ERROR, "Exception executing 'finished' callback: %s\n", ex.what());

--- a/base/task.h
+++ b/base/task.h
@@ -27,6 +27,7 @@ public:
 
   bool canceled() const { return m_canceled; }
   float progress() const { return m_progress; }
+  bool done() const { return m_canceled || m_progress == m_progress_max; }
 
   void cancel() { m_canceled = true; }
   void set_progress(float p)
@@ -60,6 +61,7 @@ public:
   ~task();
 
   void on_execute(func_t&& f) { m_execute = std::move(f); }
+  void on_done(func_t&& f) { m_done = std::move(f); }
 
   task_token& start(thread_pool& pool);
 
@@ -78,6 +80,7 @@ private:
   std::atomic<bool> m_completed;
   task_token m_token;
   func_t m_execute;
+  func_t m_done = nullptr;
 };
 
 } // namespace base

--- a/base/task.h
+++ b/base/task.h
@@ -67,6 +67,10 @@ public:
 
   bool running() const { return m_running; }
 
+  // Returns true when the task is enqueued in the thread pool's work queue,
+  // and false when the task is actually being executed.
+  bool enqueued() const { return m_enqueued; }
+
   // Returns true when the task is completed (whether it was
   // canceled or not). If this is true, it's safe to delete the task
   // instance (it will not be used anymore by any othe background
@@ -77,6 +81,7 @@ private:
   void in_worker_thread();
 
   std::atomic<bool> m_running;
+  std::atomic<bool> m_enqueued;
   std::atomic<bool> m_completed;
   task_token m_token;
   func_t m_execute;

--- a/base/task.h
+++ b/base/task.h
@@ -27,7 +27,6 @@ public:
 
   bool canceled() const { return m_canceled; }
   float progress() const { return m_progress; }
-  bool finished() const { return m_canceled || m_progress == m_progress_max; }
 
   void cancel() { m_canceled = true; }
   void set_progress(float p)
@@ -51,6 +50,7 @@ private:
   std::atomic<bool> m_canceled;
   std::atomic<float> m_progress;
   float m_progress_min, m_progress_max;
+  const thread_pool::work* m_work = nullptr;
 };
 
 class task {
@@ -71,6 +71,7 @@ public:
   void on_finished(func_t&& f) { m_finished = std::move(f); }
 
   task_token& start(thread_pool& pool);
+  bool try_skip(thread_pool& pool);
 
   bool running() const { return m_state == state::RUNNING; }
 
@@ -86,6 +87,7 @@ public:
 
 private:
   void in_worker_thread();
+  void call_finished();
 
   std::atomic<state> m_state;
   task_token m_token;

--- a/base/task.h
+++ b/base/task.h
@@ -41,6 +41,15 @@ public:
   }
 
 private:
+  task_token(const task_token& token)
+  {
+    m_canceled.store(token.m_canceled);
+    m_progress.store(token.m_progress);
+    m_progress_min = token.m_progress_min;
+    m_progress_max = token.m_progress_max;
+    m_work = token.m_work;
+  }
+
   void reset()
   {
     m_canceled = false;
@@ -63,12 +72,13 @@ public:
   };
 
   typedef std::function<void(task_token&)> func_t;
+  typedef std::function<void(const task_token&)> finfunc_t;
 
   task();
   ~task();
 
   void on_execute(func_t&& f) { m_execute = std::move(f); }
-  void on_finished(func_t&& f) { m_finished = std::move(f); }
+  void on_finished(finfunc_t&& f) { m_finished = std::move(f); }
 
   task_token& start(thread_pool& pool);
   bool try_pop(thread_pool& pool);
@@ -92,7 +102,7 @@ private:
   std::atomic<state> m_state;
   task_token m_token;
   func_t m_execute;
-  func_t m_finished = nullptr;
+  finfunc_t m_finished = nullptr;
 };
 
 } // namespace base

--- a/base/task.h
+++ b/base/task.h
@@ -72,12 +72,20 @@ public:
   };
 
   typedef std::function<void(task_token&)> func_t;
+  // Type for the "finished" callback function. A const reference to a copy of
+  // the token is received to allow safe destruction of the task inside the
+  // callback, and to let the caller know that the token cannot be modified
+  // (because there is no point in updating the token after task finalization)
   typedef std::function<void(const task_token&)> finfunc_t;
 
   task();
   ~task();
 
   void on_execute(func_t&& f) { m_execute = std::move(f); }
+  // Sets a callback that will be called after logical finalization of the task.
+  // Useful for signaling task finalization instead of using polling techniques
+  // to know if the task finished. Also, it can be used to destroy the task
+  // safely.
   void on_finished(finfunc_t&& f) { m_finished = std::move(f); }
 
   task_token& start(thread_pool& pool);

--- a/base/task.h
+++ b/base/task.h
@@ -27,7 +27,7 @@ public:
 
   bool canceled() const { return m_canceled; }
   float progress() const { return m_progress; }
-  bool done() const { return m_canceled || m_progress == m_progress_max; }
+  bool finished() const { return m_canceled || m_progress == m_progress_max; }
 
   void cancel() { m_canceled = true; }
   void set_progress(float p)
@@ -61,7 +61,7 @@ public:
   ~task();
 
   void on_execute(func_t&& f) { m_execute = std::move(f); }
-  void on_done(func_t&& f) { m_done = std::move(f); }
+  void on_finished(func_t&& f) { m_finished = std::move(f); }
 
   task_token& start(thread_pool& pool);
 
@@ -85,7 +85,7 @@ private:
   std::atomic<bool> m_completed;
   task_token m_token;
   func_t m_execute;
-  func_t m_done = nullptr;
+  func_t m_finished = nullptr;
 };
 
 } // namespace base

--- a/base/task.h
+++ b/base/task.h
@@ -71,7 +71,7 @@ public:
   void on_finished(func_t&& f) { m_finished = std::move(f); }
 
   task_token& start(thread_pool& pool);
-  bool try_skip(thread_pool& pool);
+  bool try_pop(thread_pool& pool);
 
   bool running() const { return m_state == state::RUNNING; }
 

--- a/base/thread_pool.cpp
+++ b/base/thread_pool.cpp
@@ -37,7 +37,7 @@ const thread_pool::work* thread_pool::execute(std::function<void()>&& func)
   return result;
 }
 
-bool thread_pool::try_skip(const work* w)
+bool thread_pool::try_pop(const work* w)
 {
   std::unique_lock<std::mutex> lock(m_mutex);
   for (auto it = m_work.begin(); it != m_work.end(); ++it) {

--- a/base/thread_pool.cpp
+++ b/base/thread_pool.cpp
@@ -26,12 +26,27 @@ thread_pool::~thread_pool()
   join_all();
 }
 
-void thread_pool::execute(std::function<void()>&& func)
+const thread_pool::work* thread_pool::execute(std::function<void()>&& func)
 {
+  thread_pool::work_ptr work = std::make_unique<thread_pool::work>(std::move(func));
+  const thread_pool::work* result = work.get();
   const std::unique_lock lock(m_mutex);
   ASSERT(m_running);
-  m_work.push(std::move(func));
+  m_work.push_back(std::move(work));
   m_cv.notify_one();
+  return result;
+}
+
+bool thread_pool::try_skip(const work* w)
+{
+  std::unique_lock<std::mutex> lock(m_mutex);
+  for (auto it = m_work.begin(); it != m_work.end(); ++it) {
+    if (w == it->get()) {
+      m_work.erase(it);
+      return true;
+    }
+  }
+  return false;
 }
 
 void thread_pool::wait_all()
@@ -79,9 +94,9 @@ void thread_pool::worker()
       m_cv.wait(lock, [this]() -> bool { return !m_running || !m_work.empty(); });
       running = m_running;
       if (m_running && !m_work.empty()) {
-        func = std::move(m_work.front());
+        func = std::move(m_work.front()->m_func);
         ++m_doingWork;
-        m_work.pop();
+        m_work.pop_front();
       }
     }
     try {

--- a/base/thread_pool.h
+++ b/base/thread_pool.h
@@ -9,9 +9,9 @@
 #pragma once
 
 #include <condition_variable>
+#include <deque>
 #include <functional>
 #include <mutex>
-#include <queue>
 #include <thread>
 #include <vector>
 
@@ -19,10 +19,27 @@ namespace base {
 
 class thread_pool {
 public:
+  class work {
+    friend class thread_pool;
+
+  public:
+    work(std::function<void()>&& func) { m_func = std::move(func); }
+
+  private:
+    std::function<void()> m_func = nullptr;
+  };
+
+  typedef std::unique_ptr<work> work_ptr;
+
   thread_pool(const size_t n);
   ~thread_pool();
 
-  void execute(std::function<void()>&& func);
+  const work* execute(std::function<void()>&& func);
+
+  // Tries to skip the work if it was not started yet, in other words, it
+  // removes the specified work from the queue if possible. Returns true if it
+  // was able to do so, or false otherwise.
+  bool try_skip(const work* w);
 
   // Waits until the queue is empty.
   void wait_all();
@@ -39,7 +56,7 @@ private:
   std::mutex m_mutex;
   std::condition_variable m_cv;
   std::condition_variable m_cvWait;
-  std::queue<std::function<void()>> m_work;
+  std::deque<work_ptr> m_work;
   int m_doingWork;
 };
 

--- a/base/thread_pool.h
+++ b/base/thread_pool.h
@@ -36,10 +36,9 @@ public:
 
   const work* execute(std::function<void()>&& func);
 
-  // Tries to skip the work if it was not started yet, in other words, it
-  // removes the specified work from the queue if possible. Returns true if it
+  // Removes the specified work from the queue if possible. Returns true if it
   // was able to do so, or false otherwise.
-  bool try_skip(const work* w);
+  bool try_pop(const work* w);
 
   // Waits until the queue is empty.
   void wait_all();


### PR DESCRIPTION
This PR introduces a couple of features to base::task:
- Possibility to set a new "done" callback that is called when the task completed its execution (we can change the name to completed instead of done if it makes more sense)
- New "enqueued" status, which is true when the task has been started but it is waiting in the thread pool's queue until the actual time to execute the function comes. 
- New "try_skip" method, which enables the caller to remove tasks from the queue that wasn't started yet.

This was introduced to be able to do some things in https://github.com/aseprite/aseprite/pull/5037. Like being able to redraw the "Running Scripts" window as needed (when a task is started/done) and to avoid showing the "stop" button for enqueued tasks. Because we can't dequeue tasks (this should be something to add to base::task and base::thread_pool as well I think)

Something to think about: should we use an atomic enum for the base::task state instead of 3 different atomic bools? I believe that a task should be only in one of the following states at any given time: 
- Ready (task created but not started yet) 
- Enqueued (task enqueued in thread pool's queue but not selected for execution yet)
- Running (task selected for execution and it is being executed)
- Completed (task finished execution by either success, cancellation or error)

