### PR TITLE
[win] Use SW_SHOWMAXIMIZED when first showing a maximized window (fix #5018)

### DIFF
--- a/os/win/window.cpp
+++ b/os/win/window.cpp
@@ -397,8 +397,16 @@ bool WindowWin::isVisible() const
 void WindowWin::setVisible(bool visible)
 {
   if (visible) {
-    if (m_activate)
-      ShowWindow(m_hwnd, SW_SHOWNORMAL);
+    m_firstVisible = true;
+
+    if (m_activate) {
+      if (m_startMaximized) {
+        ShowWindow(m_hwnd, SW_SHOWMAXIMIZED);
+        m_startMaximized = false;
+      }
+      else
+        ShowWindow(m_hwnd, SW_SHOWNORMAL);
+    }
     else
       ShowWindow(m_hwnd, SW_SHOWNOACTIVATE);
 
@@ -415,6 +423,14 @@ void WindowWin::activate()
 
 void WindowWin::maximize()
 {
+  if (!m_firstVisible) {
+    // If we have never flipped the display or set the window to be visible, maximize() becomes a
+    // flag so that ShowWindow is called with SW_SHOWMAXIMIZED when we have something ready to
+    // render, avoids a white screen.
+    m_startMaximized = true;
+    return;
+  }
+
   if (!isMaximized())
     ShowWindow(m_hwnd, SW_MAXIMIZE);
   else

--- a/os/win/window.h
+++ b/os/win/window.h
@@ -259,6 +259,9 @@ private:
   bool m_borderless;
   bool m_fixingPos;
   bool m_activate;
+
+  bool m_firstVisible = false;
+  bool m_startMaximized = false;
 };
 
 } // namespace os


### PR DESCRIPTION
Fixes [#5018](https://github.com/aseprite/aseprite/issues/5018), I'm not 100% sold on the exact flag method or variable names, but the fix is sound.

Here's a video showing the change (recorded at 120 fps, then slowed down 5x)

Before:

https://github.com/user-attachments/assets/0cd4f1c1-be10-4710-aea3-03d475f9b158

---

After: 


https://github.com/user-attachments/assets/bee59769-a0f5-4607-b8c4-7493518d2895

