### PR TITLE
Add configurable font hinting API

### DIFF
--- a/text/font.h
+++ b/text/font.h
@@ -12,6 +12,7 @@
 #include "base/ints.h"
 #include "base/ref.h"
 #include "gfx/fwd.h"
+#include "text/font_hinting.h"
 #include "text/font_type.h"
 #include "text/fwd.h"
 
@@ -44,6 +45,8 @@ public:
   virtual void setSize(float size) = 0;
   virtual bool antialias() const = 0;
   virtual void setAntialias(bool antialias) = 0;
+  virtual FontHinting hinting() const = 0;
+  virtual void setHinting(FontHinting hinting) = 0;
 
   bool hasCodePoint(codepoint_t cp) const { return (codePointToGlyph(cp) != 0); }
 

--- a/text/font_hinting.h
+++ b/text/font_hinting.h
@@ -1,0 +1,24 @@
+// LAF Text Library
+// Copyright (c) 2025  Igara Studio S.A.
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifndef LAF_TEXT_FONT_HINTING_H_INCLUDED
+#define LAF_TEXT_FONT_HINTING_H_INCLUDED
+#pragma once
+
+#include "base/ints.h"
+
+namespace text {
+
+enum class FontHinting : uint8_t {
+  None,
+  Slight,
+  Normal,
+  Full,
+};
+
+} // namespace text
+
+#endif

--- a/text/freetype_font.cpp
+++ b/text/freetype_font.cpp
@@ -110,6 +110,17 @@ void FreeTypeFont::setAntialias(bool antialias)
   m_face.setAntialias(antialias);
 }
 
+FontHinting FreeTypeFont::hinting() const
+{
+  return m_hinting;
+}
+
+void FreeTypeFont::setHinting(FontHinting hinting)
+{
+  m_hinting = hinting;
+  // TODO Use m_hinting where it is needed
+}
+
 glyph_t FreeTypeFont::codePointToGlyph(codepoint_t cp) const
 {
   return m_face.codePointToGlyph(cp);

--- a/text/freetype_font.h
+++ b/text/freetype_font.h
@@ -37,6 +37,8 @@ public:
   void setSize(float size) override;
   bool antialias() const override;
   void setAntialias(bool antialias) override;
+  FontHinting hinting() const override;
+  void setHinting(FontHinting hinting) override;
 
   glyph_t codePointToGlyph(codepoint_t cp) const override;
   gfx::RectF getGlyphBounds(glyph_t glyph) const override;
@@ -48,6 +50,7 @@ public:
 
 private:
   mutable Face m_face;
+  text::FontHinting m_hinting;
 };
 
 } // namespace text

--- a/text/skia_font.cpp
+++ b/text/skia_font.cpp
@@ -112,6 +112,30 @@ void SkiaFont::setAntialias(bool antialias)
   m_skFont.setEdging(antialias ? SkFont::Edging::kAntiAlias : SkFont::Edging::kAlias);
 }
 
+FontHinting SkiaFont::hinting() const
+{
+  switch (m_skFont.getHinting()) {
+    case SkFontHinting::kNone:   return text::FontHinting::None;
+    case SkFontHinting::kSlight: return text::FontHinting::Slight;
+    case SkFontHinting::kNormal: return text::FontHinting::Normal;
+    case SkFontHinting::kFull:   return text::FontHinting::Full;
+    default:                     return text::FontHinting::Normal;
+  }
+}
+
+void SkiaFont::setHinting(FontHinting hinting)
+{
+  SkFontHinting skHinting = SkFontHinting::kNormal;
+  switch (hinting) {
+    case text::FontHinting::None:   skHinting = SkFontHinting::kNone; break;
+    case text::FontHinting::Slight: skHinting = SkFontHinting::kSlight; break;
+    case text::FontHinting::Normal: skHinting = SkFontHinting::kNormal; break;
+    case text::FontHinting::Full:   skHinting = SkFontHinting::kFull; break;
+  }
+
+  m_skFont.setHinting(skHinting);
+}
+
 glyph_t SkiaFont::codePointToGlyph(codepoint_t codepoint) const
 {
   return m_skFont.unicharToGlyph(codepoint);

--- a/text/skia_font.h
+++ b/text/skia_font.h
@@ -33,6 +33,8 @@ public:
   void setSize(float size) override;
   bool antialias() const override;
   void setAntialias(bool antialias) override;
+  FontHinting hinting() const override;
+  void setHinting(FontHinting hinting) override;
 
   glyph_t codePointToGlyph(codepoint_t codepoint) const override;
   gfx::RectF getGlyphBounds(glyph_t glyph) const override;

--- a/text/sprite_sheet_font.h
+++ b/text/sprite_sheet_font.h
@@ -92,6 +92,10 @@ public:
     setSize(m_size);
   }
 
+  FontHinting hinting() const override { return FontHinting::None; }
+
+  void setHinting(FontHinting hinting) override { (void)hinting; }
+
   glyph_t codePointToGlyph(const codepoint_t codepoint) const override
   {
     glyph_t glyph = codepoint - int(' ') + 2;


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the MIT License. -->
<!-- Please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT

I was looking at https://github.com/aseprite/aseprite/issues/4931, and found the issue could be fixed when this adding after the following line:
https://github.com/aseprite/laf/blob/cc62448d580bd415c9e7259b99ac1986ed7c4212/text/skia_text_blob_shaper.cpp#L125
`skFont.setHinting(SkFontHinting::kNone);`

However, I assume we do not want hinting to be disabled by default / all the time. So this MR is setting up the necessary API for hinting to be configurable through the Aesprite app (I imagine through the top bar when the Text Tool is used).