### PR TITLE
Add method to get the native color channels order

### DIFF
--- a/os/skia/skia_surface.cpp
+++ b/os/skia/skia_surface.cpp
@@ -62,6 +62,13 @@ static SkCanvas::SrcRectConstraint to_constraint(const Paint* paint)
   return SkCanvas::kStrict_SrcRectConstraint;
 }
 
+// static
+Surface::ColorChannelsOrder Surface::getNativeColorChannelsOrder()
+{
+  return kN32_SkColorType == kRGBA_8888_SkColorType ? ColorChannelsOrder::RGB :
+                                                      ColorChannelsOrder::BGR;
+}
+
 SkiaSurface::SkiaSurface() : m_surface(nullptr), m_colorSpace(nullptr), m_canvas(nullptr), m_lock(0)
 {
 }

--- a/os/surface.h
+++ b/os/surface.h
@@ -38,6 +38,10 @@ using SurfaceRef = Ref<Surface>;
 
 class Surface : public RefCount {
 public:
+  enum class ColorChannelsOrder { RGB, BGR };
+
+  static ColorChannelsOrder getNativeColorChannelsOrder();
+
   virtual ~Surface() {}
   virtual int width() const = 0;
   virtual int height() const = 0;


### PR DESCRIPTION
Introduced to fix the "Avoid creating a temporal surface in static WEBP_CSP_MODE colorMode()..." item from https://github.com/aseprite/aseprite/issues/4777
