### PR TITLE
[osx] Fix scaling issues when painting dirty areas

### DIFF
--- a/os/skia/skia_window_osx.h
+++ b/os/skia/skia_window_osx.h
@@ -45,7 +45,7 @@ public:
   void onChangeBackingProperties() override;
 
 private:
-  void paintGC(const gfx::Rect& rect);
+  void paintGC(const gfx::RectF& rect);
 
   bool m_closing = false;
 

--- a/os/skia/skia_window_osx.mm
+++ b/os/skia/skia_window_osx.mm
@@ -192,7 +192,7 @@ void SkiaWindowOSX::onChangeBackingProperties()
     setColorSpace(colorSpace());
 }
 
-void SkiaWindowOSX::paintGC(const gfx::Rect& rect)
+void SkiaWindowOSX::paintGC(const gfx::RectF& rect)
 {
   if (!this->isInitialized())
     return;
@@ -201,7 +201,7 @@ void SkiaWindowOSX::paintGC(const gfx::Rect& rect)
     return;
 
   NSRect viewBounds = m_nsWindow.contentView.bounds;
-  int scale = this->scale();
+  float scale = this->scale();
 
   SkiaSurface* surface = static_cast<SkiaSurface*>(this->surface());
   if (!surface->isValid())
@@ -211,7 +211,7 @@ void SkiaWindowOSX::paintGC(const gfx::Rect& rect)
   const SkBitmap& origBitmap = surface->bitmap();
 
   SkBitmap bitmap;
-  if (scale == 1) {
+  if (scale == 1.0f) {
     // Create a subset to draw on the view
     if (!origBitmap.extractSubset(
           &bitmap,


### PR DESCRIPTION
The SkiaWindowOSX::paintGC was using integer units to calculate the scaled size portion of the source image that had to be updated. This caused that for odd rect sizes when using an even scale the rendering was offset by one pixel (one sub-pixel actually when scale was 2 for instance).

For reference: this issue was reported in a comment from another issue: https://github.com/aseprite/aseprite/issues/5095#issuecomment-2815292686

Steps to reproduce the issue:
1) Having the following settings:
     Screen scaling: 200%
     UI elements scaling: 100%
2) Snap the main window to the top of the screen (the right corner should do it as well).
3) Unsnap the window by dragging it from its title bar (this is the "interesting" part...unsnapping the window will make it have an odd size, not the size it had before snapping).
4) Move the mouse cursor around the bottom of the editor and the top of the timeline. You should see how the rendering of some lines of the window is offset by 1 pixel (1 subpixel actually because we are using 200% screen scaling).
