### PR TITLE
[x11] Fallback to `uname -m` if `arch` is not available

### DIFF
--- a/misc/platform.sh
+++ b/misc/platform.sh
@@ -13,7 +13,12 @@ if [[ "$uname" =~ "MINGW32" ]] || [[ "$uname" =~ "MINGW64" ]] || [[ "$uname" =~ 
     cpu=x64
 elif [[ "$uname" == "Linux" ]] ; then
     is_linux=1
-    cpu=$(arch | xargs)
+    source /etc/os-release
+    if [[ "$ID_LIKE" == *"arch"* ]] ; then
+        cpu=$(uname -m | xargs)
+    else
+        cpu=$(arch | xargs)
+    fi
     if [[ "$cpu" == "x86_64" ]] ; then
         cpu=x64
     fi


### PR DESCRIPTION
Arch-based systems don't provide the `arch` command by default.
This patch falls back to `uname -m`, which gives the same result, to
ensure compatibility without affecting other distributions.

Fixes aseprite/laf#143

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT
