### PR TITLE
Fix baseline/text height for SpriteTextBlob when fallback font is used

### DIFF
--- a/text/font.h
+++ b/text/font.h
@@ -26,7 +26,7 @@ namespace text {
 
 class Font : public base::RefCount {
 public:
-  Font() : m_fallback(nullptr) {}
+  Font() {}
   virtual ~Font() {}
   virtual FontType type() = 0;
   virtual TypefaceRef typeface() const = 0;
@@ -54,11 +54,11 @@ public:
   virtual gfx::RectF getGlyphBounds(glyph_t glyph) const = 0;
   virtual float getGlyphAdvance(glyph_t glyph) const = 0;
 
-  Font* fallback() const { return m_fallback; }
-  void setFallback(Font* font) { m_fallback = font; }
+  FontRef fallback() const { return m_fallback; }
+  void setFallback(FontRef font) { m_fallback = font; }
 
 private:
-  Font* m_fallback;
+  FontRef m_fallback;
 };
 
 } // namespace text

--- a/text/text_blob.cpp
+++ b/text/text_blob.cpp
@@ -50,6 +50,21 @@ float TextBlob::baseline()
   return m_baseline;
 }
 
+float TextBlob::textHeight()
+{
+  if (m_textHeight == 0.0f) {
+    visitRuns([this](RunInfo& info) {
+      if (!info.font)
+        return;
+
+      FontMetrics metrics;
+      info.font->metrics(&metrics);
+      m_textHeight = std::max(m_textHeight, metrics.descent - metrics.ascent);
+    });
+  }
+  return m_textHeight;
+}
+
 TextBlob::Utf8Range TextBlob::RunInfo::getGlyphUtf8Range(size_t i) const
 {
   Utf8Range subRange;

--- a/text/text_blob.h
+++ b/text/text_blob.h
@@ -74,6 +74,9 @@ public:
   // font on each run).
   float baseline();
 
+  // Returns the max(descent - ascent) for all fonts used in this text blob.
+  float textHeight();
+
   // Visits each run in the TextBlob.
   using RunVisitor = std::function<void(RunInfo&)>;
   virtual void visitRuns(const RunVisitor& visitor) = 0;
@@ -101,10 +104,12 @@ public:
 
 protected:
   void setBaseline(const float baseline) { m_baseline = baseline; }
+  void setTextHeight(const float textHeight) { m_textHeight = textHeight; }
 
 private:
   gfx::RectF m_bounds;
   float m_baseline = 0.0f;
+  float m_textHeight = 0.0f;
 };
 
 } // namespace text


### PR DESCRIPTION
We've added a new TextBlob::textHeight() field, and calculate the baseline correctly first to shape all glyphs based on that baseline later.

Needed for https://github.com/aseprite/aseprite/issues/5210
