### PR TITLE
fix: check $ID alongside $ID_LIKE in misc/platform.sh

### DIFF
--- a/misc/platform.sh
+++ b/misc/platform.sh
@@ -14,7 +14,7 @@ if [[ "$uname" =~ "MINGW32" ]] || [[ "$uname" =~ "MINGW64" ]] || [[ "$uname" =~ 
 elif [[ "$uname" == "Linux" ]] ; then
     is_linux=1
     source /etc/os-release
-    if [[ "$ID_LIKE" == *"arch"* ]] ; then
+    if [[ "$ID" == *"arch"* || "$ID_LIKE" == *"arch"* ]] ; then
         cpu=$(uname -m | xargs)
     else
         cpu=$(arch | xargs)


### PR DESCRIPTION
in archlinux, `etc/os-release` does not define `ID_LIKE`, only `ID`. the build script fails as a result of only checking `ID_LIKE`, because `$cpu` ends up being unbound, leading to unfound skia binaries.

this fix is for aseprite/aseprite#5246

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT
