### PR TITLE
[osx] Make activate() move the window to the front to match other platforms

### DIFF
--- a/os/osx/window.mm
+++ b/os/osx/window.mm
@@ -351,7 +351,7 @@ void WindowOSX::activate()
   if ([m_nsWindow.delegate respondsToSelector:@selector(windowShouldBecomeKey:)] &&
       ![(id)m_nsWindow.delegate windowShouldBecomeKey:m_nsWindow])
     return;
-  [m_nsWindow makeKeyWindow];
+  [m_nsWindow makeKeyAndOrderFront:nil];
 }
 
 void WindowOSX::maximize()


### PR DESCRIPTION
`SetWindowActive` on Windows and `_NET_ACTIVE_WINDOW` in X11 both request window activation and bring them to the front (haven't tested X11 but that seems to be the consensus), this makes OS X match that behavior.