### PR TITLE
Fix newlines causing the textHeight and baseline to use fallback font

### DIFF
--- a/text/sprite_text_blob_shaper.cpp
+++ b/text/sprite_text_blob_shaper.cpp
@@ -97,6 +97,10 @@ TextBlobRef SpriteTextBlob::MakeWithShaper(const FontMgrRef& fontMgr,
       if (chr == 0)
         break;
 
+      // Do not process newlines/control characters
+      if (chr >= 10 && chr <= 20)
+        continue;
+
       const glyph_t glyph = spriteFont->codePointToGlyph(chr);
       // Code point not found, use the fallback font or the FontMgr and
       // create a run using another TextBlob.
@@ -156,6 +160,9 @@ TextBlobRef SpriteTextBlob::MakeWithShaper(const FontMgrRef& fontMgr,
     run.utf8Range.end = i;
     if (chr == 0)
       break;
+
+    if (chr >= 10 && chr <= 20)
+      continue;
 
     const glyph_t glyph = spriteFont->codePointToGlyph(chr);
     // Code point not found, use the fallback font or the FontMgr and


### PR DESCRIPTION
Fixes aseprite/aseprite#5408

Tooltips in aseprite are one of the few things that have `\n` newline characters, so because of the changes introduced in [this commit](https://github.com/aseprite/aseprite/commit/af6e8b65c3c8a3fddba6bc95c594265c2fd6256c) the text inside those was using the fallback text height (which is by default now like twice the size of the regular one, which made it so noticeable).

The fix is now we avoid doing the processing for the most common line break codepoints and we only change the `textHeight` and `baseline` values to the fallback ones when the font actually finds a glyph for the codepoint.
