### PR TITLE
Avoid using cached ColorSpace after moving window to other display

### DIFF
--- a/os/osx/window.mm
+++ b/os/osx/window.mm
@@ -1,5 +1,5 @@
 // LAF OS Library
-// Copyright (C) 2019-2024  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2012-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -466,8 +466,8 @@ os::ScreenRef WindowOSX::screen() const
 
 os::ColorSpaceRef WindowOSX::colorSpace() const
 {
-  if (auto defaultCS = System::instance()->windowsColorSpace())
-    return defaultCS;
+  if (auto cs = Window::colorSpace())
+    return cs;
 
   ASSERT(m_nsWindow);
   return os::convert_nscolorspace_to_os_colorspace([m_nsWindow colorSpace]);

--- a/os/skia/skia_window_base.h
+++ b/os/skia/skia_window_base.h
@@ -1,5 +1,5 @@
 // LAF OS Library
-// Copyright (C) 2021-2024  Igara Studio S.A.
+// Copyright (C) 2021-2025  Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -113,9 +113,9 @@ public:
       m_surface = make_ref<SkiaSurface>();
 
       if (T::isTransparent())
-        m_surface->createRgba(newSize.w, newSize.h, m_colorSpace);
+        m_surface->createRgba(newSize.w, newSize.h, colorSpace());
       else
-        m_surface->create(newSize.w, newSize.h, m_colorSpace);
+        m_surface->create(newSize.w, newSize.h, colorSpace());
     }
   }
 
@@ -126,14 +126,16 @@ public:
   // Overrides the colorSpace() method to return the cached/stored
   // color space in this instance (instead of asking for the color
   // space to the screen as T::colorSpace() should do).
-  os::ColorSpaceRef colorSpace() const override { return m_colorSpace; }
+  os::ColorSpaceRef colorSpace() const override
+  {
+    if (m_colorSpace)
+      return m_colorSpace;
+    return T::colorSpace();
+  }
 
   void setColorSpace(const os::ColorSpaceRef& colorSpace) override
   {
-    if (colorSpace)
-      m_colorSpace = colorSpace;
-    else
-      m_colorSpace = T::colorSpace(); // Screen color space
+    m_colorSpace = colorSpace;
 
     if (m_surface)
       resetSkiaSurface();

--- a/os/skia/skia_window_osx.mm
+++ b/os/skia/skia_window_osx.mm
@@ -188,8 +188,10 @@ void SkiaWindowOSX::onEndResizing()
 
 void SkiaWindowOSX::onChangeBackingProperties()
 {
-  if (m_nsWindow)
-    setColorSpace(colorSpace());
+  if (m_nsWindow) {
+    // Set the monitor color space (bypass SkiaWindowBase::m_colorSpace).
+    setColorSpace(WindowOSX::colorSpace());
+  }
 }
 
 void SkiaWindowOSX::paintGC(const gfx::RectF& rect)

--- a/os/skia/skia_window_win.cpp
+++ b/os/skia/skia_window_win.cpp
@@ -1,5 +1,5 @@
 // LAF OS Library
-// Copyright (C) 2019-2022  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 // Copyright (C) 2012-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -184,7 +184,8 @@ void SkiaWindowWin::onEndResizing()
 
 void SkiaWindowWin::onChangeColorSpace()
 {
-  this->setColorSpace(colorSpace());
+  // Set the monitor color space (bypass SkiaWindowBase::m_colorSpace).
+  setColorSpace(WindowWin::colorSpace());
 }
 
 } // namespace os

--- a/os/win/color_space.cpp
+++ b/os/win/color_space.cpp
@@ -1,5 +1,5 @@
 // LAF OS Library
-// Copyright (C) 2018-2020  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -8,7 +8,7 @@
   #include "config.h"
 #endif
 
-#include "os/osx/color_space.h"
+#include "os/win/color_space.h"
 
 #include "base/file_content.h"
 #include "base/fs.h"

--- a/os/win/color_space.h
+++ b/os/win/color_space.h
@@ -1,5 +1,5 @@
 // LAF OS Library
-// Copyright (C) 2018-2021  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -11,6 +11,8 @@
 #include "os/color_space.h"
 
 #include <vector>
+
+#include <windows.h>
 
 namespace os {
 

--- a/os/win/window.cpp
+++ b/os/win/window.cpp
@@ -347,13 +347,8 @@ os::ScreenRef WindowWin::screen() const
 
 os::ColorSpaceRef WindowWin::colorSpace() const
 {
-  const os::SystemRef system = os::System::instance();
-  ASSERT(system);
-  if (!system)
-    return nullptr;
-
-  if (auto defaultCS = system->windowsColorSpace())
-    return defaultCS;
+  if (auto cs = Window::colorSpace())
+    return cs;
 
   if (m_hwnd) {
     HMONITOR monitor = MonitorFromWindow(m_hwnd, MONITOR_DEFAULTTONEAREST);
@@ -365,8 +360,11 @@ os::ColorSpaceRef WindowWin::colorSpace() const
     }
   }
   // sRGB by default
-  if (!m_lastColorProfile)
-    m_lastColorProfile = system->makeColorSpace(gfx::ColorSpace::MakeSRGB());
+  if (!m_lastColorProfile) {
+    if (auto system = os::System::instance())
+      m_lastColorProfile = system->makeColorSpace(gfx::ColorSpace::MakeSRGB());
+  }
+
   return m_lastColorProfile;
 }
 
@@ -2399,10 +2397,11 @@ void WindowWin::killTouchTimer()
 
 void WindowWin::checkColorSpaceChange()
 {
-  os::ColorSpaceRef oldColorSpace = m_lastColorProfile;
-  os::ColorSpaceRef newColorSpace = colorSpace();
-  if (oldColorSpace != newColorSpace)
-    onChangeColorSpace();
+  // TODO Compare if CS are different.
+  // os::ColorSpaceRef oldCS = m_lastColorProfile;
+  // os::ColorSpaceRef newCS = colorSpace();
+
+  onChangeColorSpace();
 }
 
 // We only support the Windows 11 dark mode, detecting it and using

--- a/os/window.cpp
+++ b/os/window.cpp
@@ -1,5 +1,5 @@
 // LAF OS Library
-// Copyright (C) 2019-2021  Igara Studio S.A.
+// Copyright (C) 2019-2025  Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -14,6 +14,7 @@
 #include "gfx/region.h"
 #include "os/event.h"
 #include "os/event_queue.h"
+#include "os/system.h"
 
 namespace os {
 
@@ -46,6 +47,19 @@ gfx::Point Window::pointFromScreen(const gfx::Point& screenPosition) const
 void Window::queueEvent(os::Event& ev)
 {
   onQueueEvent(ev);
+}
+
+os::ColorSpaceRef Window::colorSpace() const
+{
+  auto system = System::instance();
+  ASSERT(system);
+  if (!system)
+    return nullptr;
+
+  if (auto defaultCS = system->windowsColorSpace())
+    return defaultCS;
+
+  return nullptr;
 }
 
 void Window::setDragTarget(DragTarget* delegate)

--- a/os/window.h
+++ b/os/window.h
@@ -1,5 +1,5 @@
 // LAF OS Library
-// Copyright (c) 2018-2024  Igara Studio S.A.
+// Copyright (c) 2018-2025  Igara Studio S.A.
 // Copyright (c) 2012-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -181,7 +181,7 @@ public:
   virtual os::ScreenRef screen() const = 0;
 
   // Returns the color space of the window where the window is located.
-  virtual os::ColorSpaceRef colorSpace() const = 0;
+  virtual os::ColorSpaceRef colorSpace() const;
 
   // Changes the color space to use in this window. Can be nullptr
   // if you want to use the current monitor color space.

--- a/os/x11/window.cpp
+++ b/os/x11/window.cpp
@@ -1,5 +1,5 @@
 // LAF OS Library
-// Copyright (C) 2018-2024  Igara Studio S.A.
+// Copyright (C) 2018-2025  Igara Studio S.A.
 // Copyright (C) 2017-2018  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -502,16 +502,14 @@ os::ScreenRef WindowX11::screen() const
 
 os::ColorSpaceRef WindowX11::colorSpace() const
 {
-  auto system = System::instance();
-  ASSERT(system);
-  if (!system)
-    return nullptr;
-
-  if (auto defaultCS = system->windowsColorSpace())
-    return defaultCS;
+  if (auto cs = Window::colorSpace())
+    return cs;
 
   // TODO get the window color space
-  return system->makeColorSpace(gfx::ColorSpace::MakeSRGB());
+  if (auto system = System::instance())
+    return system->makeColorSpace(gfx::ColorSpace::MakeSRGB());
+
+  return nullptr;
 }
 
 void WindowX11::setScale(const int scale)


### PR DESCRIPTION
This is a fix for Windows and macOS (X11 CMS support is not ready).

If we move the window from one monitor to another the color space changes (this is true on Aseprite if we have the "use current monitor color profile").