### PR TITLE
[x11] Use a default ScreenX11 impl if Xrandr returns no primary monitor

### DIFF
--- a/os/x11/monitor.cpp
+++ b/os/x11/monitor.cpp
@@ -16,10 +16,10 @@ MonitorsX11::MonitorsX11()
   auto x11display = X11::instance()->display();
   ::Window root = XDefaultRootWindow(x11display);
 
-  int numMonitors;
-  XRRMonitorInfo* monitors = XRRGetMonitors(x11display, root, false, &numMonitors);
+  int nmonitors = 0;
+  XRRMonitorInfo* monitors = XRRGetMonitors(x11display, root, false, &nmonitors);
 
-  m_numMonitors = numMonitors;
+  m_numMonitors = nmonitors;
   m_monitors = unique_monitors_ptr(monitors);
 }
 
@@ -39,8 +39,8 @@ ScreenRef MonitorsX11::nearestMonitorOf(const gfx::Rect& frame) const
   ScreenRef candidate = nullptr;
   int most_area = INT_MIN;
 
-  for (int nmonitor = 0; nmonitor < m_numMonitors; nmonitor++) {
-    ScreenRef monitor = os::make_ref<ScreenX11>(nmonitor);
+  for (int i = 0; i < m_numMonitors; ++i) {
+    ScreenRef monitor = os::make_ref<ScreenX11>(i);
 
     const gfx::Rect& bounds = monitor->bounds();
     gfx::Rect segment(frame);

--- a/os/x11/monitor.h
+++ b/os/x11/monitor.h
@@ -26,7 +26,7 @@ public:
   ScreenRef nearestMonitorOf(const gfx::Rect& frame) const;
 
 private:
-  int m_numMonitors;
+  int m_numMonitors = 0;
   unique_monitors_ptr m_monitors;
 };
 

--- a/os/x11/system.h
+++ b/os/x11/system.h
@@ -1,5 +1,5 @@
 // LAF OS Library
-// Copyright (C) 2021-2024  Igara Studio S.A.
+// Copyright (C) 2021-2025  Igara Studio S.A.
 // Copyright (C) 2016  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -82,23 +82,31 @@ public:
   ScreenRef mainScreen() override
   {
     MonitorsX11* monitors = X11::instance()->monitors();
-    const int numMonitors = monitors->numMonitors();
+    const int nmonitors = monitors->numMonitors();
 
-    // we have to search for the primary monitor
-    for (int monitor = 0; monitor < numMonitors; monitor++) {
-      if (monitors->monitorInfo(monitor).primary) {
-        return make_ref<ScreenX11>(monitor);
-      }
+    // We have to search for the primary monitor
+    for (int i = 0; i < nmonitors; ++i) {
+      if (monitors->monitorInfo(i).primary)
+        return make_ref<ScreenX11>(i);
     }
 
-    return nullptr;
+    // If there is no primary monitor (or Xrandr returns 0 monitors,
+    // or no primary monitor as in the xvfb-run case), we use a dummy
+    // ScreenX11() for the XDefaultScreen() anyway.
+    return make_ref<ScreenX11>(0);
   }
 
   void listScreens(ScreenList& list) override
   {
-    const int numMonitors = X11::instance()->monitors()->numMonitors();
-    for (int monitor = 0; monitor < numMonitors; monitor++)
-      list.push_back(make_ref<ScreenX11>(monitor));
+    const int nmonitors = X11::instance()->monitors()->numMonitors();
+    if (nmonitors > 1) {
+      for (int i = 0; i < nmonitors; ++i)
+        list.push_back(make_ref<ScreenX11>(i));
+    }
+    else {
+      // Dummy screen pointer to interact with the XDefaultScreen()
+      list.push_back(make_ref<ScreenX11>(0));
+    }
   }
 
 private:


### PR DESCRIPTION
xvfb-run returns one monitor but without the "primary" flag, which was making SystemX11::mainScreen() return a nullptr (and tests crash). Now we return a valid pointer for the first monitor anyway.

If there is no monitors reported by Xrandr, we use the XDefaultScreen() information. So SystemX11::mainScreen() and listScreens() should always return one screen at least.
