### PR TITLE
Fix the position of subruns in TextBlob::visitRuns() generated by SpriteTextBlob::MakeWithShaper()

### DIFF
--- a/text/skia_text_blob.cpp
+++ b/text/skia_text_blob.cpp
@@ -1,5 +1,5 @@
 // LAF Text Library
-// Copyright (c) 2024  Igara Studio S.A.
+// Copyright (c) 2024-2025  Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -23,6 +23,11 @@ SkiaTextBlob::SkiaTextBlob(const sk_sp<SkTextBlob>& skTextBlob, const gfx::RectF
   ASSERT(skTextBlob);
 }
 
+void SkiaTextBlob::setVisitOffset(const gfx::PointF& visitOffset)
+{
+  m_visitOffset = visitOffset;
+}
+
 void SkiaTextBlob::visitRuns(const RunVisitor& visitor)
 {
   SkTextBlob::Iter iter(*m_skTextBlob);
@@ -41,6 +46,7 @@ void SkiaTextBlob::visitRuns(const RunVisitor& visitor)
       positions[i] = gfx::PointF(run.positions[i].x(), run.positions[i].y());
     }
     subInfo.positions = positions.data();
+    subInfo.point = m_visitOffset;
 
     visitor(subInfo);
   }

--- a/text/skia_text_blob.h
+++ b/text/skia_text_blob.h
@@ -1,5 +1,5 @@
 // LAF Text Library
-// Copyright (c) 2024  Igara Studio S.A.
+// Copyright (c) 2024-2025  Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -21,6 +21,7 @@ public:
 
   sk_sp<SkTextBlob> skTextBlob() const { return m_skTextBlob; }
 
+  void setVisitOffset(const gfx::PointF& visitOffset);
   void visitRuns(const RunVisitor& visitor) override;
 
   static TextBlobRef Make(const FontRef& font, const std::string& text);
@@ -33,6 +34,7 @@ public:
 
 private:
   sk_sp<SkTextBlob> m_skTextBlob;
+  gfx::PointF m_visitOffset;
 };
 
 } // namespace text

--- a/text/sprite_text_blob_shaper.cpp
+++ b/text/sprite_text_blob_shaper.cpp
@@ -17,6 +17,10 @@
 #include "text/font_mgr.h"
 #include "text/sprite_sheet_font.h"
 
+#if LAF_SKIA
+  #include "text/skia_text_blob.h"
+#endif
+
 namespace text {
 
 namespace {
@@ -211,6 +215,11 @@ TextBlobRef SpriteTextBlob::MakeWithShaper(const FontMgrRef& fontMgr,
                                              text.substr(i, j - i), // TODO use std::string_view
                                              &subHandler);
       if (run.subBlob) {
+#if LAF_SKIA
+        if (auto* skiaBlob = dynamic_cast<SkiaTextBlob*>(run.subBlob.get()))
+          skiaBlob->setVisitOffset(alignedPos);
+#endif
+
         run.positions.push_back(pos);
 
         textBounds |= run.subBlob->bounds();


### PR DESCRIPTION
This is fixes some issues in https://github.com/aseprite/aseprite/pull/5455 using visitRuns() when the blob contains subruns, e.g. when the text contains emojis or Unicode glyphs that require a fallback font/non-SpriteSheetFont.