### PR TITLE
Allow drawing the selected text background earlier

### DIFF
--- a/text/draw_text.h
+++ b/text/draw_text.h
@@ -1,5 +1,5 @@
 // LAF Text Library
-// Copyright (c) 2022-2024  Igara Studio S.A.
+// Copyright (c) 2022-2025  Igara Studio S.A.
 // Copyright (C) 2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -31,6 +31,20 @@ enum class TextAlign { Left, Center, Right };
 class DrawTextDelegate {
 public:
   virtual ~DrawTextDelegate() {}
+
+  // This is called before processing and drawing character by character.
+  // Returns true if the character index is in the range of selected characters.
+  virtual bool isSelectedChar(const int index)
+  {
+    // Do nothing
+    return false;
+  }
+
+  // This is called before processing and drawing character by character.
+  virtual void drawSelectionBg(const gfx::RectF& bounds)
+  {
+    // Do nothing
+  }
 
   // This is called before drawing the character.
   virtual void preProcessChar(const int index,

--- a/text/draw_text_shaper.cpp
+++ b/text/draw_text_shaper.cpp
@@ -1,5 +1,5 @@
 // LAF Text Library
-// Copyright (c) 2024  Igara Studio S.A.
+// Copyright (c) 2024-2025  Igara Studio S.A.
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -49,10 +49,30 @@ public:
   void commitRunBuffer(TextBlob::RunInfo& info) override
   {
     if (info.clusters && info.glyphCount > 0) {
-      float advanceX = 0.0f;
+      gfx::RectF selectionBounds;
+      gfx::RectF textBounds;
+      std::vector<gfx::RectF> glyphsBounds(info.glyphCount);
+      for (int i = 0; i < info.glyphCount; ++i) {
+        auto bounds = info.getGlyphBounds(i);
+        glyphsBounds[i] = bounds;
+        textBounds |= bounds;
+
+        if (m_delegate && m_delegate->isSelectedChar(i))
+          selectionBounds |= bounds;
+      }
 
       os::Paint paint;
       paint.style(os::Paint::Fill);
+
+      if (m_surface && m_bg != gfx::ColorNone) {
+        paint.color(m_bg);
+        m_surface->drawRect(textBounds.offset(m_origin), paint);
+      }
+
+      if (m_delegate && !selectionBounds.isEmpty())
+        m_delegate->drawSelectionBg(selectionBounds.offset(m_origin));
+
+      float advanceX = 0.0f;
 
       for (int i = 0; i < info.glyphCount; ++i) {
         int utf8Begin, utf8End;
@@ -71,7 +91,7 @@ public:
 
         const std::string utf8text = m_text.substr(utf8Begin, utf8End - utf8Begin);
 
-        gfx::RectF bounds = info.getGlyphBounds(i);
+        gfx::RectF bounds = glyphsBounds[i];
         bounds.offset(m_origin);
 
         advanceX += bounds.w;
@@ -99,11 +119,6 @@ public:
 
         if (m_delegate)
           m_delegate->preDrawChar(bounds);
-
-        if (m_bg != gfx::ColorNone) {
-          paint.color(m_bg);
-          m_surface->drawRect(bounds, paint);
-        }
 
         if (m_surface && info.font) {
           if (info.font->type() == FontType::SpriteSheet) {


### PR DESCRIPTION
This PR modifies the order in which some things are done when each run of text is processed when the shaping function is executed:
- Now, the selected text background drawing is delegated before drawing any character. In this way if the glyphs in a run overlap with each other the background drawing of the current glyph won't overwrite the previous glyph.
- Now, if there is a background color set, it is painted before drawing any character and before delegating the selected text background painting.

Both of the above things are possible because now we first calculate the union of all glyphs bounds. 

