### PR TITLE
[x11] Add movement threshold when detecting double clicks in X11

### DIFF
--- a/os/x11/window.cpp
+++ b/os/x11/window.cpp
@@ -1199,14 +1199,19 @@ void WindowX11::processX11Event(XEvent& event)
         ev.setButton(button);
 
         if (event.type == ButtonPress) {
+          gfx::Point currentPos(event.xbutton.x / m_scale, event.xbutton.y / m_scale);
+
           if (m_doubleClickButton == button &&
-              base::current_tick() - m_doubleClickTick < LAF_X11_DOUBLE_CLICK_TIMEOUT) {
+              base::current_tick() - m_doubleClickTick < LAF_X11_DOUBLE_CLICK_TIMEOUT &&
+              std::abs(currentPos.x - m_doubleClickStartPos.x) < kDoubleClickThreshold &&
+              std::abs(currentPos.y - m_doubleClickStartPos.y) < kDoubleClickThreshold) {
             ev.setType(Event::MouseDoubleClick);
             m_doubleClickButton = Event::NoneButton;
           }
           else {
             m_doubleClickButton = button;
             m_doubleClickTick = base::current_tick();
+            m_doubleClickStartPos = currentPos;
           }
         }
       }
@@ -1222,8 +1227,14 @@ void WindowX11::processX11Event(XEvent& event)
       if (event.xmotion.time == g_lastXInputEventTime)
         break;
 
-      // Reset double-click state
-      m_doubleClickButton = Event::NoneButton;
+      // Only reset double-click state if movement exceeds threshold
+      if (m_doubleClickButton != Event::NoneButton) {
+        int deltaX = std::abs(event.xmotion.x / m_scale - m_doubleClickStartPos.x);
+        int deltaY = std::abs(event.xmotion.y / m_scale - m_doubleClickStartPos.y);
+        if (deltaX >= kDoubleClickThreshold || deltaY >= kDoubleClickThreshold) {
+          m_doubleClickButton = Event::NoneButton;
+        }
+      }
 
       const gfx::Point pos(event.xmotion.x / m_scale, event.xmotion.y / m_scale);
 

--- a/os/x11/window.h
+++ b/os/x11/window.h
@@ -13,6 +13,7 @@
 #include "gfx/border.h"
 #include "gfx/color_space.h" // Include here avoid error with None
 #include "gfx/fwd.h"
+#include "gfx/point.h"
 #include "gfx/size.h"
 #include "os/color_space.h"
 #include "os/event.h"
@@ -125,6 +126,8 @@ private:
   // Double-click info
   Event::MouseButton m_doubleClickButton;
   base::tick_t m_doubleClickTick;
+  gfx::Point m_doubleClickStartPos;
+  static const int kDoubleClickThreshold = 8;
 
   static bool g_textInput;
 };


### PR DESCRIPTION
Fixes #112
This makes double clicking in aseprite much less flakey on linux, for example when using the marque tool in tile mode, or navigating directories and opening files using the aseprite file dialogs. Without this I have to be very careful to keep the mouse still when double clicking and even then I usually have to try several times to get a double click to register.

Prevents the x11 implementation from resetting the click state on mouse movement until either x or y position has changed more than a certain radius from the last clicked position. Also checks the position again before triggering a double click action just in case the position has somehow changed in a way that wasn't captured and handled.

I set it up with a fixed radius of 8, since I'm not really sure how best to go about making it build configurable or actually dynamic. But this should be a huge improvement over the existing behavior with no threshold. For comparison with windows the default radius seems to be 2, but probably works differently for touch/tablet inputs, SDL defaults to 32 which seems a bit excessive so I picked something a bit more conservative but still hopefully useful if you happen to be using touch or tablet input.

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT
