### PR TITLE
Fix platform.sh failing to detect OS on cachyos

### DIFF
--- a/misc/platform.sh
+++ b/misc/platform.sh
@@ -14,7 +14,7 @@ if [[ "$uname" =~ "MINGW32" ]] || [[ "$uname" =~ "MINGW64" ]] || [[ "$uname" =~ 
 elif [[ "$uname" == "Linux" ]] ; then
     is_linux=1
     source /etc/os-release
-    if [[ "$ID" == *"arch"* || "$ID_LIKE" == *"arch"* ]] ; then
+    if [[ "$ID" == *"arch"* || "$ID_LIKE" == *"arch"* || "$ID" == *"cachyos"* ]] ; then
         cpu=$(uname -m | xargs)
     else
         cpu=$(arch | xargs)


### PR DESCRIPTION
CachyOS is based on Arch, so the `arch` command is not available by default. It does not have the "arch" string in `/etc/os-release` file either, so platform.sh was failing to detect the architecture, causing the automatic skia download on aseprites build.sh script to fail.

CachyOS os-release file:
```shell
❯ cat /etc/os-release
NAME="CachyOS Linux"
PRETTY_NAME="CachyOS"
ID=cachyos
BUILD_ID=rolling
ANSI_COLOR="38;2;23;147;209"
HOME_URL="https://cachyos.org/"
DOCUMENTATION_URL="https://wiki.cachyos.org/"
SUPPORT_URL="https://discuss.cachyos.org/"
BUG_REPORT_URL="https://github.com/cachyos"
PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
LOGO=cachyos
```

I am not sure if CachyOS is the only impacted distro, so perhaps a more generic `"arch" command available -> use it or fallback to uname` using `command -v arch` would be more robust, but since I am not aware of the specifics and dependencies of this file, I didn't want to overreach and introduce a behaviour change.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the MIT License. -->
<!-- Please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT
