### PR TITLE
Fix combo box lists do not expand in the Preference dialog on MacOS

### DIFF
--- a/os/osx/window.mm
+++ b/os/osx/window.mm
@@ -1,5 +1,5 @@
 // LAF OS Library
-// Copyright (C) 2019-2025  Igara Studio S.A.
+// Copyright (C) 2019-present  Igara Studio S.A.
 // Copyright (C) 2012-2017  David Capello
 //
 // This file is released under the terms of the MIT license.
@@ -129,6 +129,13 @@
 
     if (spec->modal())
       self.level = NSModalPanelWindowLevel;
+
+    if (spec->parent()) {
+      NSWindow* parent =
+        (__bridge NSWindow*)static_cast<os::WindowOSX*>(spec->parent())->nativeHandle();
+      if (parent.level > self.level)
+        self.level = parent.level;
+    }
 
     // Hide the "View > Show Tab Bar" menu item
     if ([self respondsToSelector:@selector(setTabbingMode:)])


### PR DESCRIPTION
Regression of commit https://github.com/aseprite/aseprite/commit/d9785e5c363a555fcda30ad0a256abc59f5f6550: 'Fix inactive window passes events to window below (https://github.com/aseprite/aseprite/issues/4561, https://github.com/aseprite/aseprite/pull/4835)'

On MacOS, this fixes combo box lists in the Preferences dialog when the 'UI with multiple windows' option was enabled.