### PR TITLE
[win] Wake up event queue when pushing an event

### DIFF
--- a/os/event_queue_tests.cpp
+++ b/os/event_queue_tests.cpp
@@ -1,0 +1,81 @@
+// LAF OS Library
+// Copyright (C) 2026-present  Igara Studio S.A.
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
+#include <gtest/gtest.h>
+
+#include "os/event.h"
+#include "os/event_queue.h"
+#include "os/system.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+bool done = false;
+std::mutex mutex;
+std::condition_variable cv;
+
+std::thread queue_callback()
+{
+  return std::thread([]{
+    // Wait a little of time so we call getEvent() from the main thread.
+    std::this_thread::sleep_for(15ms);
+
+    os::Event ev;
+    ev.setType(os::Event::Callback);
+    ev.setCallback([]{
+      done = true;
+    });
+    os::queue_event(ev);
+  });
+}
+
+std::thread kill_me_in_two_seconds()
+{
+  return std::thread([]{
+    std::unique_lock lock(mutex);
+    if (cv.wait_for(lock, 2s) == std::cv_status::timeout) {
+      EXPECT_FALSE(true) << "Event queue is stuck";
+      std::exit(1);
+    }
+  });
+}
+
+TEST(EventQueue, WakeupForCallback)
+{
+  auto system = os::System::make();
+
+  std::thread a = kill_me_in_two_seconds();
+  std::thread b = queue_callback();
+
+  while (!done) {
+    os::Event ev;
+    os::EventQueue::instance()->getEvent(ev);
+    switch (ev.type()) {
+      case os::Event::Callback:
+        ev.execCallback();
+        break;
+    }
+  }
+
+  cv.notify_one();
+  EXPECT_TRUE(done);
+
+  b.join();
+  a.join();
+}
+
+int app_main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/os/win/event_queue.cpp
+++ b/os/win/event_queue.cpp
@@ -9,20 +9,23 @@
   #include "config.h"
 #endif
 
-#include <queue>
-
-#include <windows.h>
-
-#include "os/win/event_queue.h"
-
 #include "base/time.h"
+#include "os/win/event_queue.h"
 #include "os/win/ime_manager.h"
 
 namespace os {
 
+EventQueueWin::EventQueueWin() : m_sleeping(false)
+{
+  m_threadId = GetCurrentThreadId();
+}
+
 void EventQueueWin::queueEvent(const Event& ev)
 {
   m_events.push(ev);
+
+  if (m_sleeping.load(std::memory_order_acquire))
+    PostThreadMessage(m_threadId, WM_NULL, 0, 0);
 }
 
 void EventQueueWin::clearEvents()
@@ -38,8 +41,9 @@ void EventQueueWin::getEvent(Event& ev, double timeout)
   ev.setWindow(nullptr);
 
   while (m_events.empty()) {
-    BOOL res;
+    m_sleeping.store(true, std::memory_order_release);
 
+    BOOL res;
     if (timeout == kWithoutTimeout) {
       res = GetMessage(&msg, nullptr, 0, 0);
     }
@@ -55,6 +59,8 @@ void EventQueueWin::getEvent(Event& ev, double timeout)
       }
       res = PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE);
     }
+
+    m_sleeping.store(false, std::memory_order_release);
 
     if (res) {
       // Avoid transforming WM_KEYDOWN/UP into WM_DEADCHAR/WM_CHAR

--- a/os/win/event_queue.h
+++ b/os/win/event_queue.h
@@ -13,17 +13,23 @@
 #include "os/event.h"
 #include "os/event_queue.h"
 
+#include <atomic>
 #include <queue>
+#include <windows.h>
 
 namespace os {
 
 class EventQueueWin : public EventQueue {
 public:
+  EventQueueWin();
+
   void queueEvent(const Event& ev) override;
   void getEvent(Event& ev, double timeout) override;
   void clearEvents();
 
 private:
+  DWORD m_threadId;
+  std::atomic<bool> m_sleeping;
   base::concurrent_queue<Event> m_events;
 };
 


### PR DESCRIPTION
Fixes the issue by posting a message to the thread to wake it up.

CI failure on the skia-linked branches seems to be unrelated-ish? It's crashing because it's missing zlib.dll, it's the same reason that app_main_tests fails... is that why it's getting removed by the current github action? @dacap