### PR TITLE
[win] Use OutputDebugString instead of stderr on Windows

### DIFF
--- a/base/log.cpp
+++ b/base/log.cpp
@@ -9,6 +9,10 @@
   #include "config.h"
 #endif
 
+#ifdef LAF_WINDOWS
+  #include <windows.h>
+#endif
+
 #include "base/log.h"
 
 #include "base/debug.h"
@@ -83,8 +87,12 @@ static void LOGva(const char* format, va_list ap)
   }
 
 #ifdef _DEBUG
+  #ifdef LAF_WINDOWS
+  ::OutputDebugStringA(buf.data());
+  #else
   fputs(buf.data(), stderr);
   fflush(stderr);
+  #endif
 #endif
 }
 


### PR DESCRIPTION
fputs isn't really visible in Visual Studio, this makes LOG calls actually show up when developing on Windows

Including windows.h first because it defines ERROR because of course it does, and then log.h undefs it :^] 