### PR TITLE
change misc/platform.sh to check if arch command exists

### DIFF
--- a/misc/platform.sh
+++ b/misc/platform.sh
@@ -14,10 +14,10 @@ if [[ "$uname" =~ "MINGW32" ]] || [[ "$uname" =~ "MINGW64" ]] || [[ "$uname" =~ 
 elif [[ "$uname" == "Linux" ]] ; then
     is_linux=1
     source /etc/os-release
-    if [[ "$ID" == *"arch"* || "$ID" == *"artix"* || "$ID_LIKE" == *"arch"* ]] ; then
-        cpu=$(uname -m | xargs)
-    else
+    if [[ $(command -v arch) ]] ; then
         cpu=$(arch | xargs)
+    else
+        cpu=$(uname -m | xargs)
     fi
     if [[ "$cpu" == "x86_64" ]] ; then
         cpu=x64

--- a/misc/platform.sh
+++ b/misc/platform.sh
@@ -14,7 +14,7 @@ if [[ "$uname" =~ "MINGW32" ]] || [[ "$uname" =~ "MINGW64" ]] || [[ "$uname" =~ 
 elif [[ "$uname" == "Linux" ]] ; then
     is_linux=1
     source /etc/os-release
-    if [[ "$ID" == *"arch"* || "$ID_LIKE" == *"arch"* ]] ; then
+    if [[ "$ID" == *"arch"* || "$ID" == *"artix"* || "$ID_LIKE" == *"arch"* ]] ; then
         cpu=$(uname -m | xargs)
     else
         cpu=$(arch | xargs)


### PR DESCRIPTION
In artixlinux, an arch based distro, `etc/os-release` does not define
`ID_LIKE`. The build script fails as a result of only checking if
``"$ID" == *"arch"* || "$ID_LIKE" == *"arch"*`` because `$cpu` ends up
being unbound, leading to unfound skia binaries.

I agree that my contributions are licensed under the MIT License.
You can find a copy of this license at https://opensource.org/licenses/MIT
