### PR TITLE
Use stable_sort instead of sort

### DIFF
--- a/gfx/packing_rects.cpp
+++ b/gfx/packing_rects.cpp
@@ -89,7 +89,7 @@ bool PackingRects::pack(const Size& size, base::task_token& token)
   int i = 0;
   for (auto& rc : m_rects)
     rectPtrs[i++] = &rc;
-  std::sort(rectPtrs.begin(), rectPtrs.end(), by_area);
+  std::stable_sort(rectPtrs.begin(), rectPtrs.end(), by_area);
 
   gfx::Region rgn(m_bounds);
   i = 0;


### PR DESCRIPTION
While reviewing https://github.com/aseprite/aseprite/pull/5829 I found the actual fix to aseprite/aseprite#5624.

So today I've learned that std::sort doesn't work the same in all platforms when the elements are equals, this is the reason why in Linux the "packed" sprite sheet presented a different result than in Windows and macOS. So using std::stable_sort makes the relative order of the original collection to stay the same when the elements are equals across all platforms.

