### PR TITLE
Fix application slows over time on MacOS (fix aseprite/aseprite#3256)

### DIFF
--- a/os/osx/view.mm
+++ b/os/osx/view.mm
@@ -178,6 +178,9 @@ using namespace os;
 - (void)removeImpl
 {
   @autoreleasepool {
+    // This is "hack" because AppKit doesn't dealloc the NSWindow's.
+    // TODO the final solution should be to dealloc each NSWindow.
+    self.layer.contents = nil;
     // Reconfigure the view to release the CALayer object. This along
     // with the autoreleasepool in initWithFrame: are needed.
     self.layer.drawsAsynchronously = false;


### PR DESCRIPTION
Verified with instruments.

Without the fix: ￼
<img width="1498" height="160" alt="Screenshot 2026-08-11 at 3 48 32 PM" src="https://github.com/user-attachments/assets/63d30fde-1d8e-4f20-b644-5ac473fea8dc" />


With the fix:
<img width="1488" height="142" alt="Screenshot 2026-08-11 at 3 48 15 PM" src="https://github.com/user-attachments/assets/be224cdd-8744-4277-9f78-96fc684a9f9a" />

 ￼
fix [aseprite/aseprite#3256](https://github.com/aseprite/aseprite/issues/3256)